### PR TITLE
Notification delivery from extension

### DIFF
--- a/BlueShift-iOS-Extension-SDK/BlueShiftPushAnalytics.h
+++ b/BlueShift-iOS-Extension-SDK/BlueShiftPushAnalytics.h
@@ -1,0 +1,14 @@
+//
+//  BlueShiftPushAnalytics.h
+//  BlueShift-iOS-Extension-SDK
+//
+//  Created by shahas kp on 11/10/17.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface BlueShiftPushAnalytics : NSObject
+
++ (void)sendPushAnalytics:(NSString *)type withParams:(NSDictionary *)userInfo;
+
+@end

--- a/BlueShift-iOS-Extension-SDK/BlueShiftPushAnalytics.m
+++ b/BlueShift-iOS-Extension-SDK/BlueShiftPushAnalytics.m
@@ -1,0 +1,122 @@
+//
+//  BlueShiftPushAnalytics.m
+//  BlueShift-iOS-Extension-SDK
+//
+//  Created by shahas kp on 11/10/17.
+//
+
+#import "BlueShiftPushAnalytics.h"
+#import "SDKVersion.h"
+#import "BlueShiftPushNotification.h"
+
+#define kBaseURL                        @"https://api.getblueshift.com/"
+#define kPushEventsUploadURL            @"track"
+#define kStatusCodeSuccessfullResponse  200
+
+@implementation BlueShiftPushAnalytics
+
++ (void)sendPushAnalytics:(NSString *)type withParams:(NSDictionary *)userInfo {
+    NSDictionary *pushTrackParameterDictionary = [self pushTrackParameterDictionaryForPushDetailsDictionary:userInfo];
+    NSMutableDictionary *parameterMutableDictionary = [NSMutableDictionary dictionary];
+    if (pushTrackParameterDictionary) {
+        [parameterMutableDictionary addEntriesFromDictionary:pushTrackParameterDictionary];
+    }
+    [parameterMutableDictionary setObject:type forKey:@"a"];
+    NSString *url = [NSString stringWithFormat:@"%@%@", kBaseURL, kPushEventsUploadURL];
+    [self fireAPICallWithURL:url data:parameterMutableDictionary andRetryCount:3];
+}
+
++ (void)fireAPICallWithURL:(NSString *)url data:(NSDictionary *)params andRetryCount:(NSInteger)count {
+    [self getRequestWithURL:url andParams:params completetionHandler:^(BOOL status, NSDictionary *response, NSError *error) {
+        if (!status && count > 0) {
+            [self fireAPICallWithURL:url data:params andRetryCount:count-1];
+        }
+    }];
+}
+
++ (NSDictionary *)pushTrackParameterDictionaryForPushDetailsDictionary:(NSDictionary *)pushDetailsDictionary {
+    
+    NSString *bsft_experiment_uuid = [pushDetailsDictionary objectForKey:@"bsft_experiment_uuid"];
+    NSString *bsft_user_uuid = [pushDetailsDictionary objectForKey:@"bsft_user_uuid"];
+    NSString *message_uuid = [pushDetailsDictionary objectForKey:@"bsft_message_uuid"];
+    NSString *transactional_uuid = [pushDetailsDictionary objectForKey:@"bsft_transactional_uuid"];
+    NSString *sdkVersion = [NSString stringWithFormat:@"%@", kSDKVersionNumber];
+    NSMutableDictionary *pushTrackParametersMutableDictionary = [NSMutableDictionary dictionary];
+    if (bsft_user_uuid) {
+        [pushTrackParametersMutableDictionary setObject:bsft_user_uuid forKey:@"uid"];
+    }
+    if(bsft_experiment_uuid) {
+        [pushTrackParametersMutableDictionary setObject:bsft_experiment_uuid forKey:@"eid"];
+    }
+    if (message_uuid) {
+        [pushTrackParametersMutableDictionary setObject:message_uuid forKey:@"mid"];
+    }
+    if (transactional_uuid) {
+        [pushTrackParametersMutableDictionary setObject:transactional_uuid forKey:@"txnid"];
+    }
+    if (sdkVersion) {
+        [pushTrackParametersMutableDictionary setObject:sdkVersion forKey:@"bsft_sdk_version"];
+    }
+    return [pushTrackParametersMutableDictionary copy];
+}
+
++ (NSURLSessionConfiguration *)addBasicAuthenticationRequestHeaderForUsername:(NSString *)username andPassword:(NSString *)password {
+    if (password==nil || password == NULL) {
+        password = @"";
+    }
+    // Generates the Base 64 encryption for the request ...
+    // Adds it to the request Header ...
+    
+    NSString *credentials = [NSString stringWithFormat:@"%@:%@",username,password];
+    NSData *credentialsData = [credentials dataUsingEncoding:NSUTF8StringEncoding];
+    NSString *credentialsBase64String = [credentialsData base64EncodedStringWithOptions:0];
+    
+    NSURLSessionConfiguration *defaultConfigObject = [NSURLSessionConfiguration defaultSessionConfiguration];
+    defaultConfigObject.HTTPAdditionalHeaders = @{
+                                                  @"Authorization":credentialsBase64String,
+                                                  @"Content-Type":@"application/json"
+                                                  };
+    return defaultConfigObject;
+}
+
++ (void) getRequestWithURL:(NSString *)urlString andParams:(NSDictionary *)params completetionHandler:(void (^)(BOOL, NSDictionary *,NSError *))handler{
+    NSURLSessionConfiguration* sessionConfiguraion = [self addBasicAuthenticationRequestHeaderForUsername:[[BlueShiftPushNotification sharedInstance] apiKey] andPassword:@""];
+    NSURLSession *defaultSession = [NSURLSession sessionWithConfiguration: sessionConfiguraion delegate: nil delegateQueue: [NSOperationQueue mainQueue]];
+    
+    NSString *paramsString = [[NSString alloc] init];
+    for(id key in params) {
+        if(paramsString.length > 0) {
+            paramsString = [NSString stringWithFormat:@"%@&%@=%@", paramsString, key, [params objectForKey:key]];
+        } else {
+            paramsString = [NSString stringWithFormat:@"%@=%@", key, [params objectForKey:key]];
+        }
+    }
+    
+    NSString *urlWithParams = [NSString stringWithFormat:@"%@?%@", urlString, paramsString];
+    
+    NSURL * url = [NSURL URLWithString:urlWithParams];
+    NSMutableURLRequest * urlRequest = [NSMutableURLRequest requestWithURL:url];
+    
+    [urlRequest setHTTPMethod:@"GET"];
+    
+    NSURLSessionDataTask * dataTask =[defaultSession dataTaskWithRequest:urlRequest
+                                                       completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                                                           if(error == nil)
+                                                           {
+                                                               NSInteger statusCode = [(NSHTTPURLResponse *)response statusCode];
+                                                               
+                                                               if (statusCode == kStatusCodeSuccessfullResponse) {
+                                                                   NSDictionary *dictionary  = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+                                                                   handler(true, dictionary, error);
+                                                               } else {
+                                                                   handler(false, nil, error);
+                                                               }
+                                                           } else {
+                                                               handler(false, nil, error);
+                                                           }
+                                                           
+                                                       }];
+    [dataTask resume];
+}
+
+@end

--- a/BlueShift-iOS-Extension-SDK/BlueShiftPushNotification.h
+++ b/BlueShift-iOS-Extension-SDK/BlueShiftPushNotification.h
@@ -12,10 +12,12 @@
 @interface BlueShiftPushNotification : NSObject
 
 @property NSArray <UNNotificationAttachment *>* attachments;
+@property NSString *apiKey;
 
 + (instancetype) sharedInstance;
 - (NSArray *)integratePushNotificationWithMediaAttachementsForRequest:(UNNotificationRequest *)request;
 - (BOOL)isBlueShiftPushNotification:(UNNotificationRequest *)request;
 - (BOOL)hasBlueShiftAttachments;
+- (void)trackPushViewedWithRequest:(UNNotificationRequest *)request;
 
 @end

--- a/BlueShift-iOS-Extension-SDK/BlueShiftPushNotification.m
+++ b/BlueShift-iOS-Extension-SDK/BlueShiftPushNotification.m
@@ -7,6 +7,7 @@
 
 
 #import "BlueShiftPushNotification.h"
+#import "BlueShiftPushAnalytics.h"
 
 
 static BlueShiftPushNotification *_sharedInstance = nil;
@@ -38,11 +39,18 @@ static BlueShiftPushNotification *_sharedInstance = nil;
 }
 
 - (NSArray *)integratePushNotificationWithMediaAttachementsForRequest:(UNNotificationRequest *)request {
-    
+    [self trackPushViewedWithRequest:request];
     if ([request.content.categoryIdentifier isEqualToString: @"carousel"] || [request.content.categoryIdentifier isEqualToString: @"carousel_animation"]) {
         return [self carouselAttachmentsDownload:request];
     } else {
         return [self mediaAttachmentDownlaod:request];
+    }
+}
+
+- (void)trackPushViewedWithRequest:(UNNotificationRequest *)request {
+    NSDictionary *userInfo = request.content.userInfo;
+    if(userInfo) {
+        [BlueShiftPushAnalytics sendPushAnalytics:@"delivered" withParams:userInfo];
     }
 }
 

--- a/BlueShift-iOS-Extension-SDK/BlueShiftPushNotification.m
+++ b/BlueShift-iOS-Extension-SDK/BlueShiftPushNotification.m
@@ -39,7 +39,9 @@ static BlueShiftPushNotification *_sharedInstance = nil;
 }
 
 - (NSArray *)integratePushNotificationWithMediaAttachementsForRequest:(UNNotificationRequest *)request {
-    [self trackPushViewedWithRequest:request];
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        [self trackPushViewedWithRequest:request];
+    });
     if ([request.content.categoryIdentifier isEqualToString: @"carousel"] || [request.content.categoryIdentifier isEqualToString: @"carousel_animation"]) {
         return [self carouselAttachmentsDownload:request];
     } else {

--- a/BlueShift-iOS-Extension-SDK/BlueShiftPushNotification.m
+++ b/BlueShift-iOS-Extension-SDK/BlueShiftPushNotification.m
@@ -51,7 +51,7 @@ static BlueShiftPushNotification *_sharedInstance = nil;
 
 - (void)trackPushViewedWithRequest:(UNNotificationRequest *)request {
     NSDictionary *userInfo = request.content.userInfo;
-    if(userInfo) {
+    if(userInfo && [[BlueShiftPushNotification sharedInstance] apiKey] && ![[[BlueShiftPushNotification sharedInstance] apiKey] isEqualToString:@""]) {
         [BlueShiftPushAnalytics sendPushAnalytics:@"delivered" withParams:userInfo];
     }
 }

--- a/BlueShift-iOS-Extension-SDK/SDKVersion.h
+++ b/BlueShift-iOS-Extension-SDK/SDKVersion.h
@@ -1,0 +1,13 @@
+//
+//  SDKVersion.h
+//  Pods
+//
+//  Created by shahas kp on 11/10/17.
+//
+
+#ifndef SDKVersion_h
+#define SDKVersion_h
+
+#define kSDKVersionNumber   @"0.2.9"
+
+#endif /* SDKVersion_h */


### PR DESCRIPTION
*Whenever push notification service extension invoke it will try to send push notification delivered event if it has bsft api key
*It create event parameters dictionary from the push notification payload which received.
*Event api is calling inside a background thread parallel with image download (if it has images) with retry count of 3