### PR TITLE
Namespace Reachability to avoid duplicate symbol errors

### DIFF
--- a/BlueShift-iOS-SDK/BlueShiftNetworkReachabilityManager.m
+++ b/BlueShift-iOS-SDK/BlueShiftNetworkReachabilityManager.m
@@ -25,7 +25,7 @@
 // Method to check whether internet is connected ...
 
 + (BOOL)networkConnected {
-    Reachability *reach = [Reachability reachabilityWithHostName:@"www.google.com"];
+    BlueShiftReachability *reach = [BlueShiftReachability reachabilityWithHostName:@"www.google.com"];
     if (reach.currentReachabilityStatus == ReachableViaWiFi || reach.currentReachabilityStatus == ReachableViaWWAN) {
         return YES;
     } else {

--- a/BlueShift-iOS-SDK/NetworkReachability.h
+++ b/BlueShift-iOS-SDK/NetworkReachability.h
@@ -43,7 +43,7 @@ FOUNDATION_EXPORT const unsigned char ReachabilityVersionString[];
 #define NS_ENUM(_type, _name) enum _name : _type _name; enum _name : _type
 #endif
 
-extern NSString *const kReachabilityChangedNotification;
+extern NSString *const kBlueShiftReachabilityChangedNotification;
 
 typedef NS_ENUM(NSInteger, NetworkStatus) {
     // Apple NetworkStatus Compatible Names.
@@ -52,14 +52,14 @@ typedef NS_ENUM(NSInteger, NetworkStatus) {
     ReachableViaWWAN = 1
 };
 
-@class Reachability;
+@class BlueShiftReachability;
 
-typedef void (^NetworkReachable)(Reachability * reachability);
-typedef void (^NetworkUnreachable)(Reachability * reachability);
-typedef void (^NetworkReachability)(Reachability * reachability, SCNetworkConnectionFlags flags);
+typedef void (^NetworkReachable)(BlueShiftReachability * reachability);
+typedef void (^NetworkUnreachable)(BlueShiftReachability * reachability);
+typedef void (^NetworkReachability)(BlueShiftReachability * reachability, SCNetworkConnectionFlags flags);
 
 
-@interface Reachability : NSObject
+@interface BlueShiftReachability : NSObject
 
 @property (nonatomic, copy) NetworkReachable    reachableBlock;
 @property (nonatomic, copy) NetworkUnreachable  unreachableBlock;

--- a/BlueShift-iOS-SDK/NetworkReachability.m
+++ b/BlueShift-iOS-SDK/NetworkReachability.m
@@ -458,7 +458,7 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
     
     // this makes sure the change notification happens on the MAIN THREAD
     dispatch_async(dispatch_get_main_queue(), ^{
-        [[NSNotificationCenter defaultCenter] postNotificationName:kReachabilityChangedNotification 
+        [[NSNotificationCenter defaultCenter] postNotificationName:kBlueShiftReachabilityChangedNotification 
                                                             object:self];
     });
 }

--- a/BlueShift-iOS-SDK/NetworkReachability.m
+++ b/BlueShift-iOS-SDK/NetworkReachability.m
@@ -35,10 +35,10 @@
 #import <netdb.h>
 
 
-NSString *const kReachabilityChangedNotification = @"kReachabilityChangedNotification";
+NSString *const kBlueShiftReachabilityChangedNotification = @"kReachabilityChangedNotification";
 
 
-@interface Reachability ()
+@interface BlueShiftReachability ()
 
 @property (nonatomic, assign) SCNetworkReachabilityRef  reachabilityRef;
 @property (nonatomic, strong) dispatch_queue_t          reachabilitySerialQueue;
@@ -73,7 +73,7 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
 {
 #pragma unused (target)
 
-    Reachability *reachability = ((__bridge Reachability*)info);
+    BlueShiftReachability *reachability = ((__bridge BlueShiftReachability*)info);
 
     // We probably don't need an autoreleasepool here, as GCD docs state each queue has its own autorelease pool,
     // but what the heck eh?
@@ -84,13 +84,13 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
 }
 
 
-@implementation Reachability
+@implementation BlueShiftReachability
 
 #pragma mark - Class Constructor Methods
 
 +(instancetype)reachabilityWithHostName:(NSString*)hostname
 {
-    return [Reachability reachabilityWithHostname:hostname];
+    return [BlueShiftReachability reachabilityWithHostname:hostname];
 }
 
 +(instancetype)reachabilityWithHostname:(NSString*)hostname


### PR DESCRIPTION
According to the TonyMillion Reachability page:

**WARNING there have been reports of apps being rejected when Reachability is used in a framework. The only solution to this so far is to rename the class.**

The Reachability class is causing duplicate errors if it's included in another Framework that you're using (which in my case it is). This class should be namespaced since you're including it in your Framework.