### PR TITLE
[MOBL-247]: feature - added BlueshiftDeviceIdSourceIDFVBundleID as device_id provision

### DIFF
--- a/BlueShift-iOS-SDK/BlueShiftConfig.m
+++ b/BlueShift-iOS-SDK/BlueShiftConfig.m
@@ -24,7 +24,7 @@
         self.inAppBackgroundFetchEnabled = YES;
         self.inAppManualTriggerEnabled = NO;
         
-        //BlueshiftDeviceIdSourceIDFV
+        //Default BlueshiftDeviceIdSource
         self.blueshiftDeviceIdSource = BlueshiftDeviceIdSourceIDFV;
     }
     return self;

--- a/BlueShift-iOS-SDK/BlueShiftConfig.m
+++ b/BlueShift-iOS-SDK/BlueShiftConfig.m
@@ -23,6 +23,9 @@
         self.enableInAppNotification = NO;
         self.inAppBackgroundFetchEnabled = YES;
         self.inAppManualTriggerEnabled = NO;
+        
+        //BlueshiftDeviceIdSourceIDFV
+        self.blueshiftDeviceIdSource = BlueshiftDeviceIdSourceIDFV;
     }
     return self;
 }

--- a/BlueShift-iOS-SDK/BlueShiftDeviceData.m
+++ b/BlueShift-iOS-SDK/BlueShiftDeviceData.m
@@ -30,7 +30,10 @@ static BlueShiftDeviceData *_currentDeviceData = nil;
             [defaults setObject:UUID forKey: @"BlueshiftDeviceIdSourceUUID"];
             deviceUUID = [UUID copy];
         }
-    } else {
+    } else if (_blueshiftDeviceIdSource && _blueshiftDeviceIdSource == BlueshiftDeviceIdSourceIDFVBundleID && [[NSBundle mainBundle] bundleIdentifier] != nil) {
+         NSString* bundleId = [[NSBundle mainBundle] bundleIdentifier];
+         deviceUUID = [NSString stringWithFormat:@"%@:%@", self.deviceIDFV,bundleId];
+     } else {
         deviceUUID = self.deviceIDFV;
     }
     return deviceUUID;

--- a/BlueShift-iOS-SDK/BlueShiftDeviceData.m
+++ b/BlueShift-iOS-SDK/BlueShiftDeviceData.m
@@ -21,20 +21,35 @@ static BlueShiftDeviceData *_currentDeviceData = nil;
 
 - (NSString *)deviceUUID {
     NSString *deviceUUID = @"";
-    if (_blueshiftDeviceIdSource && _blueshiftDeviceIdSource == BlueshiftDeviceIdSourceUUID) {
-        NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-        if ([defaults stringForKey:@"BlueshiftDeviceIdSourceUUID"]) {
-            deviceUUID = [defaults stringForKey:@"BlueshiftDeviceIdSourceUUID"];
-        } else {
-            NSString* UUID = [[NSUUID UUID] UUIDString];
-            [defaults setObject:UUID forKey: @"BlueshiftDeviceIdSourceUUID"];
-            deviceUUID = [UUID copy];
+    switch (_blueshiftDeviceIdSource) {
+        case BlueshiftDeviceIdSourceIDFV:
+            deviceUUID = self.deviceIDFV;
+            break;
+        case BlueshiftDeviceIdSourceUUID:
+        {
+            NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+            if ([defaults stringForKey:@"BlueshiftDeviceIdSourceUUID"]) {
+                deviceUUID = [defaults stringForKey:@"BlueshiftDeviceIdSourceUUID"];
+            } else {
+                NSString* UUID = [[NSUUID UUID] UUIDString];
+                [defaults setObject:UUID forKey: @"BlueshiftDeviceIdSourceUUID"];
+                deviceUUID = [UUID copy];
+            }
         }
-    } else if (_blueshiftDeviceIdSource && _blueshiftDeviceIdSource == BlueshiftDeviceIdSourceIDFVBundleID && [[NSBundle mainBundle] bundleIdentifier] != nil) {
-         NSString* bundleId = [[NSBundle mainBundle] bundleIdentifier];
-         deviceUUID = [NSString stringWithFormat:@"%@:%@", self.deviceIDFV,bundleId];
-     } else {
-        deviceUUID = self.deviceIDFV;
+            break;
+        case BlueshiftDeviceIdSourceIDFVBundleID:
+        {
+            NSString* bundleId = [[NSBundle mainBundle] bundleIdentifier];
+            if (bundleId != nil) {
+                deviceUUID = [NSString stringWithFormat:@"%@:%@", self.deviceIDFV,bundleId];
+            } else {
+                NSLog(@"[BlueShift] - ERROR: Failed to get the bundle Id");
+            }
+        }
+            break;
+        default:
+            deviceUUID = self.deviceIDFV;
+            break;
     }
     return deviceUUID;
 }

--- a/BlueShift-iOS-SDK/BlueshiftDeviceIdSource.h
+++ b/BlueShift-iOS-SDK/BlueshiftDeviceIdSource.h
@@ -11,7 +11,8 @@
 
 typedef NS_ENUM(NSInteger, BlueshiftDeviceIdSource)  {
     BlueshiftDeviceIdSourceIDFV,
-    BlueshiftDeviceIdSourceUUID
+    BlueshiftDeviceIdSourceUUID,
+    BlueshiftDeviceIdSourceIDFVBundleID
 };
 
 #endif /* BlueshiftDeviceIdSource_h */


### PR DESCRIPTION
Allow host app to select "device_Id" as "IDFV:BundleID"
eg- "83dd664f-f059-4e75-8e70-a59d3497bfb1:com.blueshift.reads"


