### PR TITLE
Enabling dialog box push notifications

### DIFF
--- a/BlueShift-iOS-Extension-SDK/BlueShiftPushAnalytics.m
+++ b/BlueShift-iOS-Extension-SDK/BlueShiftPushAnalytics.m
@@ -64,7 +64,8 @@
     NSURLSession *defaultSession = [NSURLSession sessionWithConfiguration: sessionConfiguraion delegate: nil delegateQueue: [NSOperationQueue mainQueue]];
     
     NSString *paramsString = [[NSString alloc] init];
-    for(id key in params) {
+    NSArray *keys = [[params allKeys] sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)];
+    for(id key in keys) {
         if(paramsString.length > 0) {
             paramsString = [NSString stringWithFormat:@"%@&%@=%@", paramsString, key, [params objectForKey:key]];
         } else {

--- a/BlueShift-iOS-SDK/BlueShift.m
+++ b/BlueShift-iOS-SDK/BlueShift.m
@@ -130,6 +130,9 @@ static BlueShift *_sharedBlueShiftInstance = nil;
         }];
     }
     
+    //Mark app open
+    [blueShiftAppDelegate trackAppOpenWithParameters:nil];
+    
     [BlueShiftNetworkReachabilityManager monitorNetworkConnectivity];
 }
 

--- a/BlueShift-iOS-SDK/BlueShift.m
+++ b/BlueShift-iOS-SDK/BlueShift.m
@@ -187,7 +187,7 @@ static BlueShift *_sharedBlueShiftInstance = nil;
         } else if ([BlueshiftEventAnalyticsHelper isMarkInAppAsOpen:dictionary]) {
             if (_inAppNotificationMananger) {
                 NSDictionary *silentPushData = [[dictionary objectForKey: kSilentNotificationPayloadIdentifierKey] objectForKey: kInAppNotificationModalSilentPushKey];
-                NSArray * messageUUIDArray = [silentPushData objectForKey:kInAppNotificationOpenedInAppUUID];
+                NSArray * messageUUIDArray = (NSArray*)[silentPushData objectForKey:kInAppNotificationOpenedInAppUUID];
                 [_inAppNotificationMananger markAsDisplayedForNotificationsViewedOnOtherDevice:messageUUIDArray];
             }
         } else if(_config.inAppManualTriggerEnabled == NO){
@@ -617,7 +617,7 @@ static BlueShift *_sharedBlueShiftInstance = nil;
     if (parameters) {
         [parameterMutableDictionary addEntriesFromDictionary:parameters];
     }
-    [parameterMutableDictionary setObject:kSDKVersionNumber forKey:@"bsft_sdk_version"];
+    [parameterMutableDictionary setObject:kSDKVersionNumber forKey:kInAppNotificationModalSDKVersionKey];
     
     [self performRequestWithRequestParameters:[parameterMutableDictionary copy] canBatchThisEvent:isBatchEvent];
 }

--- a/BlueShift-iOS-SDK/BlueShiftAlertView.m
+++ b/BlueShift-iOS-SDK/BlueShiftAlertView.m
@@ -13,8 +13,12 @@
     
     NSDictionary *pushAlertDictionary = [pushDetailsDictionary objectForKey:@"aps"];
     NSString *pushCategory = [[pushDetailsDictionary objectForKey:@"aps"] objectForKey:@"category"];
-    NSString *pushMessage = [pushAlertDictionary objectForKey:@"alert"];
-    UIAlertController *blueShiftAlertController = [UIAlertController alertControllerWithTitle:kAlertTitle message:pushMessage preferredStyle:UIAlertControllerStyleAlert];
+    NSString *pushTitle = [[pushAlertDictionary objectForKey:@"alert"] objectForKey:@"title"];
+    if (!pushTitle || [pushTitle isEqualToString:@""]) {
+        pushTitle = kAlertTitle;
+    }
+    NSString *pushMessage = [[pushAlertDictionary objectForKey:@"alert"] objectForKey:@"body"];
+    UIAlertController *blueShiftAlertController = [UIAlertController alertControllerWithTitle:pushTitle message:pushMessage  preferredStyle:UIAlertControllerStyleAlert];
     if ([pushCategory isEqualToString:kNotificationCategoryBuyIdentifier]) {
         UIAlertAction *dismissAction = [UIAlertAction actionWithTitle:kDismissButton style:UIAlertActionStyleCancel handler:nil];
         UIAlertAction *viewAction = [UIAlertAction actionWithTitle:kViewButton style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {

--- a/BlueShift-iOS-SDK/BlueShiftAppDelegate.h
+++ b/BlueShift-iOS-SDK/BlueShiftAppDelegate.h
@@ -64,6 +64,7 @@
 - (void)appDidBecomeActive:(UIApplication *_Nonnull)application;
 - (void)handleBlueshiftUniversalLinksForActivity:(NSUserActivity *_Nonnull)activity API_AVAILABLE(ios(8.0));
 - (void)handleBlueshiftUniversalLinksForURL:(NSURL *_Nonnull)url  API_AVAILABLE(ios(8.0));
+- (void)trackAppOpenWithParameters:(NSDictionary *_Nullable)parameters;
 
 @end
 #endif

--- a/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
+++ b/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
@@ -977,7 +977,7 @@
 - (NSURL *)applicationDocumentsDirectory {
     // The directory the application uses to store the Core Data store file. This code uses a directory in the application's documents directory.
     
-    if([[[BlueShift sharedInstance] config] appGroupID] != nil && (![[[[BlueShift sharedInstance] config] appGroupID] isEqualToString:@""]))
+    if([[[BlueShift sharedInstance] config] appGroupID] != nil && ![[[[BlueShift sharedInstance] config] appGroupID] isEqualToString:@""])
         return [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:[[[BlueShift sharedInstance] config] appGroupID]];
     else
         return [[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] lastObject];

--- a/BlueShift-iOS-SDK/BlueShiftDeepLink.m
+++ b/BlueShift-iOS-SDK/BlueShiftDeepLink.m
@@ -83,7 +83,6 @@ static NSDictionary *_deepLinkList = nil;
     }];
     
     if (![schemes containsObject:[url scheme]]) {
-        NSLog(@"Deep link URL not found / Something wrong with URL / or schema url");
         return NO;
     }
     

--- a/BlueShift-iOS-SDK/BlueShiftNotificationConstants.h
+++ b/BlueShift-iOS-SDK/BlueShiftNotificationConstants.h
@@ -13,6 +13,7 @@
 #define kNotificationCategoryIdentifierKey                              @"category"
 #define kNotificationSoundIdentifierKey                                 @"sound"
 #define kNotificationTypeIdentifierKey                                  @"notification_type"
+#define kNotificationKey                                                @"notification"
 #define kNotificationCarouselElementIdentifierKey                       @"carousel_elements"
 
 #define kNotificationCategoryBuyIdentifier                              @"buy"
@@ -41,7 +42,6 @@
 #define kInAppNotificationModalExperimentIDKey                          @"bsft_experiment_uuid"
 #define kInAppNotificationModalUserIDKey                                @"bsft_user_uuid"
 #define kInAppNotificationModalTransactionIDKey                         @"bsft_transaction_uuid"
-#define kInAppNotificationModalElementKey                               @"element"
 #define kInAppNotificationModalUIDKey                                   @"uid"
 #define kInAppNotificationModalEIDKey                                   @"eid"
 #define kInAppNotificationModalMIDKey                                   @"mid"

--- a/BlueShift-iOS-SDK/BlueShiftRequestOperationManager.m
+++ b/BlueShift-iOS-SDK/BlueShiftRequestOperationManager.m
@@ -7,6 +7,7 @@
 
 #import "BlueShiftRequestOperationManager.h"
 #import "BlueShiftNotificationConstants.h"
+#import "./InApps/BlueShiftInAppNotificationConstant.h"
 
 static BlueShiftRequestOperationManager *_sharedRequestOperationManager = nil;
 
@@ -48,10 +49,22 @@ static BlueShiftRequestOperationManager *_sharedRequestOperationManager = nil;
     if(_backgroundSession == NULL) {
         _backgroundSession = [NSURLSession sessionWithConfiguration: self.sessionConfiguraion delegate: nil delegateQueue: [NSOperationQueue mainQueue]];
     }
-    
+    //add below params to the end of get url
+    NSArray *keysAddedInEnd = [NSArray arrayWithObjects:@"device_id", @"app_name", kNotificationClickElementKey,kNotificationURLElementKey,nil];
+    NSMutableArray *availbleKeysToAddAtEnd = [[NSMutableArray alloc] init];
+    //remove the params which needs to be added in the end
+    NSMutableDictionary *filteredParams = [params mutableCopy];
+    for (NSString* key in keysAddedInEnd) {
+        if ([filteredParams objectForKey:key]) {
+            [filteredParams removeObjectForKey:key];
+            [availbleKeysToAddAtEnd addObject:key];
+        }
+    }
+    //Add rest of params first in sorted order and then add the params to be added in the end
     NSString *paramsString = [[NSString alloc] init];
-    NSArray *keys = [[params allKeys] sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)];
-    for(id key in keys) {
+    NSArray *filteredKeys = [[filteredParams allKeys] sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)];
+    NSArray *finalKeys = [filteredKeys arrayByAddingObjectsFromArray:availbleKeysToAddAtEnd];
+    for(id key in finalKeys) {
         if(paramsString.length > 0) {
             paramsString = [NSString stringWithFormat:@"%@&%@=%@", paramsString, key, [params objectForKey:key]];
         } else {

--- a/BlueShift-iOS-SDK/BlueShiftRequestOperationManager.m
+++ b/BlueShift-iOS-SDK/BlueShiftRequestOperationManager.m
@@ -50,7 +50,8 @@ static BlueShiftRequestOperationManager *_sharedRequestOperationManager = nil;
     }
     
     NSString *paramsString = [[NSString alloc] init];
-    for(id key in params) {
+    NSArray *keys = [[params allKeys] sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)];
+    for(id key in keys) {
         if(paramsString.length > 0) {
             paramsString = [NSString stringWithFormat:@"%@&%@=%@", paramsString, key, [params objectForKey:key]];
         } else {

--- a/BlueShift-iOS-SDK/BlueShiftRequestOperationManager.m
+++ b/BlueShift-iOS-SDK/BlueShiftRequestOperationManager.m
@@ -7,7 +7,7 @@
 
 #import "BlueShiftRequestOperationManager.h"
 #import "BlueShiftNotificationConstants.h"
-#import "./InApps/BlueShiftInAppNotificationConstant.h"
+#import "InApps/BlueShiftInAppNotificationConstant.h"
 
 static BlueShiftRequestOperationManager *_sharedRequestOperationManager = nil;
 
@@ -56,8 +56,8 @@ static BlueShiftRequestOperationManager *_sharedRequestOperationManager = nil;
     NSMutableDictionary *filteredParams = [params mutableCopy];
     for (NSString* key in keysAddedInEnd) {
         if ([filteredParams objectForKey:key]) {
+            [availbleKeysToAddAtEnd addObject:[key copy]];
             [filteredParams removeObjectForKey:key];
-            [availbleKeysToAddAtEnd addObject:key];
         }
     }
     //Add rest of params first in sorted order and then add the params to be added in the end

--- a/BlueShift-iOS-SDK/BlueShiftUserNotificationCenterDelegate.m
+++ b/BlueShift-iOS-SDK/BlueShiftUserNotificationCenterDelegate.m
@@ -17,10 +17,12 @@
 
 - (void)handleUserNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler API_AVAILABLE(ios(10.0)){
     NSDictionary *userInfo = notification.request.content.userInfo;
-    if([[userInfo objectForKey:@"notification_type"] isEqualToString:@"notification"]) {
+    if([[userInfo objectForKey:kNotificationTypeIdentifierKey] isEqualToString:kNotificationKey]) {
         completionHandler(UNAuthorizationOptionSound | UNAuthorizationOptionAlert | UNAuthorizationOptionBadge);
-    } else {
+    } else if([[userInfo objectForKey:kNotificationTypeIdentifierKey] isEqualToString:kNotificationAlertIdentifierKey]) {
         [[BlueShift sharedInstance].appDelegate presentInAppAlert:notification.request.content.userInfo];
+    } else {
+        completionHandler(UNAuthorizationOptionSound | UNAuthorizationOptionAlert | UNAuthorizationOptionBadge);
     }
 }
 
@@ -33,9 +35,9 @@
 - (void)handleUserNotification:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler  API_AVAILABLE(ios(10.0)){
     if([response.actionIdentifier isEqualToString:@"com.apple.UNNotificationDefaultActionIdentifier"]) {
         [[BlueShift sharedInstance].appDelegate handleRemoteNotification:response.notification.request.content.userInfo];
+        completionHandler();
     } else {
-        [[BlueShift sharedInstance].appDelegate handleActionWithIdentifier:response.actionIdentifier forRemoteNotification:response.notification.request.content.userInfo completionHandler:^{
-        }];
+        [[BlueShift sharedInstance].appDelegate handleActionWithIdentifier:response.actionIdentifier forRemoteNotification:response.notification.request.content.userInfo completionHandler: completionHandler];
     }
 }
 

--- a/BlueShift-iOS-SDK/BlueShiftUserNotificationCenterDelegate.m
+++ b/BlueShift-iOS-SDK/BlueShiftUserNotificationCenterDelegate.m
@@ -21,8 +21,6 @@
         completionHandler(UNAuthorizationOptionSound | UNAuthorizationOptionAlert | UNAuthorizationOptionBadge);
     } else if([[userInfo objectForKey:kNotificationTypeIdentifierKey] isEqualToString:kNotificationAlertIdentifierKey]) {
         [[BlueShift sharedInstance].appDelegate presentInAppAlert:notification.request.content.userInfo];
-    } else {
-        completionHandler(UNAuthorizationOptionSound | UNAuthorizationOptionAlert | UNAuthorizationOptionBadge);
     }
 }
 

--- a/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotification.h
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotification.h
@@ -32,6 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, readwrite, nullable) NSString* buttonType;
 @property (nonatomic, assign, readwrite, nullable) NSNumber *backgroundRadius;
 @property (nonatomic, assign, readwrite, nullable) NSNumber *textSize;
+@property (nonatomic, assign, readwrite) NSString* buttonIndex;
 
 @end
 

--- a/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationConstant.h
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationConstant.h
@@ -66,6 +66,7 @@
 #define kInAppNotificationModalSharableTextKey                  @"shareable_text"
 #define kInAppNotificationModalBackgroundRadiusKey              @"background_radius"
 #define kInAppNotificationModalTextSizeKey                      @"text_size"
+#define kInAppNotificationButtonIndex                           @"button_"
 
 /* Define a Font */
 #define kInAppNotificationModalFontExtensionKey                 @"otf"
@@ -92,7 +93,7 @@
 /*  Define a Button type */
 #define kInAppNotificationButtonTypeKey                         @"type"
 #define kInAppNotificationButtonTypeDismissKey                  @"dismiss"
-#define kInAppNotificationButtonTypeCloseKey                    @"close"
+#define kInAppNotificationButtonTypeCloseKey                    @"button_close"
 #define kInAppNotificationButtonTypeOpenKey                     @"open"
 #define kInAppNotificationButtonTypeShareKey                    @"share"
 
@@ -116,7 +117,8 @@
 #define kInAppNotificationModalGravityStartKey                  @"start"
 #define kInAppNotificationModalGravityEndKey                    @"end"
 
-#define kInAppNotificationModalElementsKey                      @"element"
+#define kNotificationClickElementKey                            @"bsft_click_element"
+#define kNotificationURLElementKey                              @"bsft_click_url"
 #define kInAppNotificationFontFileDownlaodURL                   @"https://bsftassets.s3-us-west-2.amazonaws.com/inapp/Font+Awesome+5+Free-Solid-900.otf"
 
 #define kInAppNotificationModalMessagePaddingKey                @"message_padding"

--- a/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationConstant.h
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationConstant.h
@@ -66,7 +66,7 @@
 #define kInAppNotificationModalSharableTextKey                  @"shareable_text"
 #define kInAppNotificationModalBackgroundRadiusKey              @"background_radius"
 #define kInAppNotificationModalTextSizeKey                      @"text_size"
-#define kInAppNotificationButtonIndex                           @"button_"
+#define kInAppNotificationButtonIndex                           @"btn_"
 
 /* Define a Font */
 #define kInAppNotificationModalFontExtensionKey                 @"otf"
@@ -93,7 +93,7 @@
 /*  Define a Button type */
 #define kInAppNotificationButtonTypeKey                         @"type"
 #define kInAppNotificationButtonTypeDismissKey                  @"dismiss"
-#define kInAppNotificationButtonTypeCloseKey                    @"button_close"
+#define kInAppNotificationButtonTypeCloseKey                    @"close"
 #define kInAppNotificationButtonTypeOpenKey                     @"open"
 #define kInAppNotificationButtonTypeShareKey                    @"share"
 
@@ -117,8 +117,8 @@
 #define kInAppNotificationModalGravityStartKey                  @"start"
 #define kInAppNotificationModalGravityEndKey                    @"end"
 
-#define kNotificationClickElementKey                            @"bsft_click_element"
-#define kNotificationURLElementKey                              @"bsft_click_url"
+#define kNotificationClickElementKey                            @"clk_url"
+#define kNotificationURLElementKey                              @"clk_elmt"
 #define kInAppNotificationFontFileDownlaodURL                   @"https://bsftassets.s3-us-west-2.amazonaws.com/inapp/Font+Awesome+5+Free-Solid-900.otf"
 
 #define kInAppNotificationModalMessagePaddingKey                @"message_padding"

--- a/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationHelper.h
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationHelper.h
@@ -21,6 +21,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)deleteFileFromLocal:(NSString *) fileName;
 + (CGFloat)convertHeightToPercentage:(UIView *) notificationView;
 + (CGFloat)convertPercentageHeightToPoints:(float) height;
++ (NSString*)getEncodedURLString:(NSString*) urlString;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationHelper.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationHelper.m
@@ -82,4 +82,14 @@ static NSDictionary *_inAppTypeDictionay;
     return presentationAreaHeight;
 }
 
++ (NSString*)getEncodedURLString:(NSString*) urlString {
+    if (urlString && ![urlString isEqualToString:@""]) {
+        NSString *charactersToEscape = @"!*'();:@&=+$,/?%#[]<>^`\{|}"" ";
+        NSCharacterSet *allowedCharacters = [[NSCharacterSet characterSetWithCharactersInString:charactersToEscape] invertedSet];
+        NSString *escapedURLString = [urlString stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
+        return escapedURLString;
+    }
+    return urlString;
+}
+
 @end

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationModalViewController.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationModalViewController.m
@@ -392,7 +392,7 @@
         for (int i = 0; i< actionsCount; i++) {
             CGRect cgRect = CGRectMake(xPosition, yPosition , buttonWidth, buttonHeight);
             [self createActionButton: self.notification.notificationContent.actions[i] positionButton: cgRect objectPosition: &i];
-            
+            self.notification.notificationContent.actions[i].buttonIndex = [NSString stringWithFormat:@"%@%d",kInAppNotificationButtonIndex,i];
              if (self.notification.contentStyle && self.notification.contentStyle.actionsOrientation.intValue > 0) {
                  yPosition = yPosition + buttonHeight + yPadding;
              } else {

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationViewController.h
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationViewController.h
@@ -48,7 +48,7 @@ controller;
 - (CGFloat)getLabelHeight:(UILabel*)label labelWidth:(CGFloat)width;
 - (UIView *)createNotificationWindow;
 - (void)loadImageFromLocal:(UIImageView *)imageView imageFilePath:(NSString *)filePath;
-- (void)sendActionEventAnalytics:(NSString *)elementType;
+- (void)sendActionEventAnalytics:(NSDictionary *)details;
 - (int)getTextAlignement:(NSString *)alignmentString;
 - (BOOL)isValidString:(NSString *)data;
 - (void)setBackgroundImageFromURL:(UIView *)notificationView;

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationViewController.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationViewController.m
@@ -100,7 +100,6 @@
 - (void)loadImageFromURL:(UIImageView *)imageView andImageURL:(NSString *)imageURL andWidth:(double)width andHeight:(double)height{
     NSData * imageData = [[NSData alloc] initWithContentsOfURL: [NSURL URLWithString:imageURL]];
     UIImage *image = [[UIImage alloc] initWithData:imageData];
-//    UIImage *image = [[UIImage alloc] initWithData:imageData];
     
     // resize image
     CGSize newSize = CGSizeMake(imageView.frame.size.width, imageView.frame.size.height);

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationViewController.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationViewController.m
@@ -48,7 +48,8 @@
 }
 
 - (void)closeButtonDidTapped {
-    NSDictionary *details = @{kNotificationClickElementKey:kInAppNotificationButtonTypeCloseKey};
+    NSString *closeButtonIndex = [NSString stringWithFormat:@"%@%@",kInAppNotificationButtonIndex,kInAppNotificationButtonTypeCloseKey];
+    NSDictionary *details = @{kNotificationClickElementKey:closeButtonIndex};
     [self sendActionEventAnalytics: details];
     [self hide:YES];
 }

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationViewController.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationViewController.m
@@ -48,7 +48,8 @@
 }
 
 - (void)closeButtonDidTapped {
-    [self sendActionEventAnalytics: kInAppNotificationButtonTypeCloseKey];
+    NSDictionary *details = @{kNotificationClickElementKey:kInAppNotificationButtonTypeCloseKey};
+    [self sendActionEventAnalytics: details];
     [self hide:YES];
 }
 
@@ -233,7 +234,16 @@
 }
 
 - (void)handleActionButtonNavigation:(BlueShiftInAppNotificationButton *)buttonDetails {
-    [self sendActionEventAnalytics: buttonDetails.text];
+    NSURL *deepLinkURL = [NSURL URLWithString: buttonDetails.iosLink];
+    NSString *encodedURLString = [BlueShiftInAppNotificationHelper getEncodedURLString:deepLinkURL.absoluteString];
+    NSMutableDictionary *details = [[NSMutableDictionary alloc]init];
+    if (encodedURLString) {
+        [details setValue:encodedURLString forKey:kNotificationURLElementKey];
+    }
+    if (buttonDetails.buttonIndex) {
+        [details setValue:buttonDetails.buttonIndex forKey:kNotificationClickElementKey];
+    }
+    [self sendActionEventAnalytics: details];
     
     if (buttonDetails && buttonDetails.buttonType) {
         if (self.inAppNotificationDelegate && [self.inAppNotificationDelegate respondsToSelector:@selector(actionButtonDidTapped:)] && self.notification) {
@@ -249,7 +259,6 @@
         } else {
             if([BlueShift sharedInstance].appDelegate.oldDelegate && [[BlueShift sharedInstance].appDelegate.oldDelegate respondsToSelector:@selector(application:openURL:options:)]
                     && buttonDetails.iosLink && ![buttonDetails.iosLink isEqualToString:@""]) {
-                NSURL *deepLinkURL = [NSURL URLWithString: buttonDetails.iosLink];
                 if (@available(iOS 9.0, *)) {
                     [[BlueShift sharedInstance].appDelegate.oldDelegate application:[UIApplication sharedApplication] openURL: deepLinkURL options:@{}];
                 }
@@ -276,11 +285,13 @@
     [self hide:YES];
 }
 
-- (void)sendActionEventAnalytics:(NSString *)elementType {
+- (void)sendActionEventAnalytics:(NSDictionary *)details {
     if (self.delegate && [self.delegate respondsToSelector:@selector(inAppActionDidTapped: fromViewController:)]
         && self.notification) {
         NSMutableDictionary *notificationPayload = [self.notification.notificationPayload mutableCopy];
-        [notificationPayload setObject: elementType forKey: kInAppNotificationModalElementsKey];
+        if (details) {
+            [notificationPayload addEntriesFromDictionary: details];
+        }
         [self.delegate inAppActionDidTapped : notificationPayload fromViewController:self];
     }
 }

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationWebViewController.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationWebViewController.m
@@ -207,8 +207,9 @@ API_AVAILABLE(ios(8.0))
     
     if (navigationAction.navigationType == WKNavigationTypeLinkActivated) {
         NSURL *url = navigationAction.request.URL;
-        [self sendActionEventAnalytics: url.absoluteString];
-        
+        NSString *encodedURLString = [BlueShiftInAppNotificationHelper getEncodedURLString:url.absoluteString];
+        NSDictionary *details = @{kNotificationURLElementKey:encodedURLString};
+        [self sendActionEventAnalytics: details];
         if (self.inAppNotificationDelegate && [self.inAppNotificationDelegate respondsToSelector:@selector(actionButtonDidTapped:)]) {
             NSMutableDictionary *actionPayload = [[NSMutableDictionary alloc] init];
             [actionPayload setObject: url.absoluteString forKey: kInAppNotificationModalPageKey];

--- a/BlueShift-iOS-SDK/InApps/BlueshiftInAppNotificationRequest.m
+++ b/BlueShift-iOS-SDK/InApps/BlueshiftInAppNotificationRequest.m
@@ -26,7 +26,7 @@
                                         @"bsft_message_uuid" : lastMessageID,
                                         @"api_key" : apiKey,
                                         @"last_timestamp" : (lastTimestamp && ![lastTimestamp isEqualToString:@""]) ? lastTimestamp :@0,
-                                        @"bsft_sdk_version" : kSDKVersionNumber
+                                        kInAppNotificationModalSDKVersionKey : kSDKVersionNumber
                                         } mutableCopy];
         [parameters addEntriesFromDictionary:[BlueShiftDeviceData currentDeviceData].toDictionary];
         [parameters addEntriesFromDictionary:[BlueShiftAppData currentAppData].toDictionary];


### PR DESCRIPTION
- [MOBL-316] Enabled dialog box push notifications
- alphabetical order for params for GET URL 
- [MOBL-309] Added clk_url, clk_elmt,app_name,device_id params at the end of the GET URL
- removed deep link log statements
- added completion handler for BlueshiftUNUsernotificationCenterDelegate
- added URL encoding for HTML in-app URLs clicks and push notification deep link clicks.
- Check for AppGroupID for an empty string
- [MOBL-318] Removed app_open on DidBecome active and on receiving a silent push.
- Added app_open on blueshift config and opening app via push 
- Removed trackAppOpen and trackPushViewed methods as they were not getting used
- Universal links URL tracking marked as batch false for /track URLs

[MOBL-316]: https://blueshift.atlassian.net/browse/MOBL-316
[MOBL-309]: https://blueshift.atlassian.net/browse/MOBL-309
[MOBL-318]: https://blueshift.atlassian.net/browse/MOBL-318