### PR TITLE
Feature/blueshift logger

### DIFF
--- a/BlueShift-iOS-Extension-SDK/BlueShiftPushAnalytics.m
+++ b/BlueShift-iOS-Extension-SDK/BlueShiftPushAnalytics.m
@@ -77,7 +77,6 @@
     NSString *encodedString = [urlWithParams stringByReplacingOccurrencesOfString:@" " withString:kBsftEncodedSpace];
     NSURL * url = [NSURL URLWithString:encodedString];
     NSMutableURLRequest * urlRequest = [NSMutableURLRequest requestWithURL:url];
-    
     [urlRequest setHTTPMethod:@"GET"];
     
     NSURLSessionDataTask * dataTask =[defaultSession dataTaskWithRequest:urlRequest

--- a/BlueShift-iOS-Extension-SDK/BlueShiftPushNotification.m
+++ b/BlueShift-iOS-Extension-SDK/BlueShiftPushNotification.m
@@ -52,11 +52,9 @@ static BlueShiftPushNotification *_sharedInstance = nil;
 - (NSArray *)integratePushNotificationWithMediaAttachementsForRequest:(UNNotificationRequest *)request andAppGroupID:(NSString *)appGroupID {
     [[BlueShiftPushNotification sharedInstance] setBlueshiftInAppNotification: request andAppGroupID: appGroupID];
     
-    #ifdef DEBUG
     if (![[BlueShiftPushNotification sharedInstance] apiKey] || [[BlueShiftPushNotification sharedInstance].apiKey isEqualToString:@""]) {
         NSLog(@"[Blueshift] Error - Please set the api key in the Notification Service Extension, otherwise push notification delivered events will not reflect on the dashboard");
     }
-    #endif
     
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         [self trackPushViewedWithRequest:request];

--- a/BlueShift-iOS-Extension-SDK/BlueShiftPushNotification.m
+++ b/BlueShift-iOS-Extension-SDK/BlueShiftPushNotification.m
@@ -52,6 +52,12 @@ static BlueShiftPushNotification *_sharedInstance = nil;
 - (NSArray *)integratePushNotificationWithMediaAttachementsForRequest:(UNNotificationRequest *)request andAppGroupID:(NSString *)appGroupID {
     [[BlueShiftPushNotification sharedInstance] setBlueshiftInAppNotification: request andAppGroupID: appGroupID];
     
+    #ifdef DEBUG
+    if (![[BlueShiftPushNotification sharedInstance] apiKey] || [[BlueShiftPushNotification sharedInstance].apiKey isEqualToString:@""]) {
+        NSLog(@"[Blueshift] Error - Please set the api key in the Notification Service Extension, otherwise push notification delivered events will not reflect on the dashboard");
+    }
+    #endif
+    
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         [self trackPushViewedWithRequest:request];
     });
@@ -92,9 +98,11 @@ static BlueShiftPushNotification *_sharedInstance = nil;
                  NSString  *filePathToWrite = [NSString stringWithFormat:@"%@/%@", documentsDirectory, attachmentName];
                  [imageData writeToFile:filePathToWrite atomically:YES];
                  
-                 NSError *error3;
-                 UNNotificationAttachment *attachment = [UNNotificationAttachment attachmentWithIdentifier:attachmentName URL:URL options:nil error:&error3];
-                 NSLog(@"%@", error3);
+                 NSError *error;
+                 UNNotificationAttachment *attachment = [UNNotificationAttachment attachmentWithIdentifier:attachmentName URL:URL options:nil error:&error];
+                 if (error) {
+                     NSLog(@"[Blueshift] Failed to create carousel image attachment %@", error);
+                 }
                  if(attachment != nil) {
                      [attachments addObject:attachment];
                      self.attachments = attachments;
@@ -130,9 +138,11 @@ static BlueShiftPushNotification *_sharedInstance = nil;
             NSString  *filePathToWrite = [NSString stringWithFormat:@"%@/%@", documentsDirectory, attachmentName];
             [imageData writeToFile:filePathToWrite atomically:YES];
             
-            NSError *error3;
-            UNNotificationAttachment *attachment = [UNNotificationAttachment attachmentWithIdentifier:attachmentName URL:URL options:nil error:&error3];
-            NSLog(@"%@", error3);
+            NSError *error;
+            UNNotificationAttachment *attachment = [UNNotificationAttachment attachmentWithIdentifier:attachmentName URL:URL options:nil error:&error];
+            if (error) {
+                NSLog(@"[Blueshift] Failed to create image attachment %@", error);
+            }
             if(attachment != nil) {
                 [attachments addObject:attachment];
             }
@@ -150,9 +160,11 @@ static BlueShiftPushNotification *_sharedInstance = nil;
             NSString  *filePathToWrite = [NSString stringWithFormat:@"%@/%@", documentsDirectory, attachmentName];
             [videoData writeToFile:filePathToWrite atomically:YES];
             
-            NSError *error3;
-            UNNotificationAttachment *attachment = [UNNotificationAttachment attachmentWithIdentifier:attachmentName URL:URL options:nil error:&error3];
-            NSLog(@"%@", error3);
+            NSError *error;
+            UNNotificationAttachment *attachment = [UNNotificationAttachment attachmentWithIdentifier:attachmentName URL:URL options:nil error:&error];
+            if (error) {
+                NSLog(@"[Blueshift] Failed to create video attachment %@", error);
+            }
             if(attachment != nil) {
                 [attachments addObject:attachment];
             }
@@ -170,9 +182,11 @@ static BlueShiftPushNotification *_sharedInstance = nil;
             NSString  *filePathToWrite = [NSString stringWithFormat:@"%@/%@", documentsDirectory, attachmentName];
             [gifData writeToFile:filePathToWrite atomically:YES];
             
-            NSError *error3;
-            UNNotificationAttachment *attachment = [UNNotificationAttachment attachmentWithIdentifier:attachmentName URL:URL options:nil error:&error3];
-            NSLog(@"%@", error3);
+            NSError *error;
+            UNNotificationAttachment *attachment = [UNNotificationAttachment attachmentWithIdentifier:attachmentName URL:URL options:nil error:&error];
+            if (error) {
+                NSLog(@"[Blueshift] Failed to create gif image attachment %@", error);
+            }
             if(attachment != nil) {
                 [attachments addObject:attachment];
             }
@@ -190,9 +204,11 @@ static BlueShiftPushNotification *_sharedInstance = nil;
             NSString  *filePathToWrite = [NSString stringWithFormat:@"%@/%@", documentsDirectory, attachmentName];
             [audioData writeToFile:filePathToWrite atomically:YES];
             
-            NSError *error3;
-            UNNotificationAttachment *attachment = [UNNotificationAttachment attachmentWithIdentifier:attachmentName URL:URL options:nil error:&error3];
-            NSLog(@"%@", error3);
+            NSError *error;
+            UNNotificationAttachment *attachment = [UNNotificationAttachment attachmentWithIdentifier:attachmentName URL:URL options:nil error:&error];
+            if (error) {
+                NSLog(@"[Blueshift] Failed to create audio attachment %@", error);
+            }
             if(attachment != nil) {
                 [attachments addObject:attachment];
             }

--- a/BlueShift-iOS-Extension-SDK/BlueshiftInAppEntityAppDelegate.m
+++ b/BlueShift-iOS-Extension-SDK/BlueshiftInAppEntityAppDelegate.m
@@ -32,7 +32,7 @@
             [fetchRequest setEntity:entity];
         }
         @catch (NSException *exception) {
-            NSLog(@"Caught exception %@", exception);
+            NSLog(@"[Blueshift] Caught exception %@", exception);
         }
 
         if(entity != nil && fetchRequest.entity != nil) {
@@ -60,7 +60,7 @@
                 entity = [NSEntityDescription entityForName: kInAppNotificationEntityNameKey inManagedObjectContext: self.managedObjectContext];
             }
             @catch (NSException *exception) {
-                NSLog(@"Caught exception %@", exception);
+                NSLog(@"[Blueshift] Caught exception %@", exception);
             }
             
             if(entity != nil) {
@@ -76,10 +76,10 @@
                         }];
                     }
                     @catch (NSException *exception) {
-                        NSLog(@"Caught exception %@", exception);
+                        NSLog(@"[Blueshift] Caught exception %@", exception);
                     }
                 } else {
-                    printf("\n App entity is nil");
+                    NSLog(@"[Blueshift] App entity is nil");
                 }
             }
         }
@@ -146,7 +146,7 @@
         error = [NSError errorWithDomain:@"YOUR_ERROR_DOMAIN" code:9999 userInfo:dict];
         // Replace this with code to handle the error appropriately.
         // abort() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-        NSLog(@"Unresolved error %@, %@", error, [error userInfo]);
+        NSLog(@"[Blueshift] Unresolved error %@, %@", error, [error userInfo]);
     }
     
     return _persistentStoreCoordinator;
@@ -207,7 +207,7 @@
         if ([managedObjectContext hasChanges] && ![managedObjectContext save:&error]) {
             // Replace this implementation with code to handle the error appropriately.
             // abort() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-            NSLog(@"Unresolved error %@, %@", error, [error userInfo]);
+            NSLog(@"[Blueshift] Unresolved error %@, %@", error, [error userInfo]);
         }
     }
 }

--- a/BlueShift-iOS-Extension-SDK/InAppNotificationEntity.m
+++ b/BlueShift-iOS-Extension-SDK/InAppNotificationEntity.m
@@ -60,7 +60,7 @@ usingPrivateContext: (NSManagedObjectContext*)privateContext
             }
         }
         @catch (NSException *exception) {
-            NSLog(@"Caught exception %@", exception);
+            NSLog(@"[Blueshift] Caught exception %@", exception);
             handler(NO);
         }
     } else {
@@ -90,7 +90,7 @@ usingPrivateContext: (NSManagedObjectContext*)privateContext
         }
     }
     @catch (NSException *exception) {
-        NSLog(@"Caught exception %@", exception);
+        NSLog(@"[Blueshift] Caught exception %@", exception);
     }
 }
 

--- a/BlueShift-iOS-SDK.xcodeproj/project.pbxproj
+++ b/BlueShift-iOS-SDK.xcodeproj/project.pbxproj
@@ -322,7 +322,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 0610;
-				ORGANIZATIONNAME = "Bullfinch Software";
+				ORGANIZATIONNAME = Blueshift;
 				TargetAttributes = {
 					DC4ECE191A9B53430078CCB0 = {
 						CreatedOnToolsVersion = 6.1.1;

--- a/BlueShift-iOS-SDK.xcodeproj/project.pbxproj
+++ b/BlueShift-iOS-SDK.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		55BD2C061D9172F300422869 /* NSDate+BlueShiftDateHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 55BD2BF01D9172F300422869 /* NSDate+BlueShiftDateHelpers.m */; };
 		55BD2C071D9172F300422869 /* NSNumber+BlueShiftHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 55BD2BF21D9172F300422869 /* NSNumber+BlueShiftHelpers.m */; };
 		55C739171E28A31200A5EAE4 /* BlueShiftLiveContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 55C739161E28A31200A5EAE4 /* BlueShiftLiveContent.m */; };
+		910EADF224D17AC4003D3DC9 /* BlueshiftLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 910EADF124D17AC4003D3DC9 /* BlueshiftLog.m */; };
 		DC7125C71AA76ABB00D6C30E /* CoreTelephony.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC7125C61AA76ABB00D6C30E /* CoreTelephony.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		DCA6202F1AA4F2AA001EC26B /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCA6201F1AA4E303001EC26B /* CoreData.framework */; };
 		DCA620301AA4F4D6001EC26B /* BlueShiftModelBundle.bundle in Resources */ = {isa = PBXBuildFile; fileRef = DCA620271AA4F129001EC26B /* BlueShiftModelBundle.bundle */; };
@@ -130,6 +131,8 @@
 		55BD2BF21D9172F300422869 /* NSNumber+BlueShiftHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSNumber+BlueShiftHelpers.m"; sourceTree = "<group>"; };
 		55C739151E28A31200A5EAE4 /* BlueShiftLiveContent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlueShiftLiveContent.h; sourceTree = "<group>"; };
 		55C739161E28A31200A5EAE4 /* BlueShiftLiveContent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BlueShiftLiveContent.m; sourceTree = "<group>"; };
+		910EADF024D17ABD003D3DC9 /* BlueshiftLog.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BlueshiftLog.h; sourceTree = "<group>"; };
+		910EADF124D17AC4003D3DC9 /* BlueshiftLog.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BlueshiftLog.m; sourceTree = "<group>"; };
 		913F9B8E2492455E0032CD4A /* BlueshiftDeviceIdSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BlueshiftDeviceIdSource.h; sourceTree = "<group>"; };
 		99CE5242ED9870A5D4A5BADE /* Pods-BlueShift-iOS-SDK.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BlueShift-iOS-SDK.release.xcconfig"; path = "Pods/Target Support Files/Pods-BlueShift-iOS-SDK/Pods-BlueShift-iOS-SDK.release.xcconfig"; sourceTree = "<group>"; };
 		9A09163D6DFCFEE31B4B799F /* Pods-BlueShift-iOS-SDK.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BlueShift-iOS-SDK.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BlueShift-iOS-SDK/Pods-BlueShift-iOS-SDK.debug.xcconfig"; sourceTree = "<group>"; };
@@ -268,6 +271,8 @@
 				555A39AC1ECDA8030067D21C /* BlueShiftPushNotification.m */,
 				555A39AD1ECDA8030067D21C /* iCarousel.h */,
 				555A39AE1ECDA8030067D21C /* iCarousel.m */,
+				910EADF024D17ABD003D3DC9 /* BlueshiftLog.h */,
+				910EADF124D17AC4003D3DC9 /* BlueshiftLog.m */,
 			);
 			path = "BlueShift-iOS-SDK";
 			sourceTree = "<group>";
@@ -335,6 +340,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = E0D6B90D1A92513E008485D8;
@@ -403,6 +409,7 @@
 				555A39B11ECDA8030067D21C /* iCarousel.m in Sources */,
 				55BD2BF91D9172F300422869 /* BlueShiftConfig.m in Sources */,
 				55BD2BF71D9172F300422869 /* BlueShiftBatchRequestOperation.m in Sources */,
+				910EADF224D17AC4003D3DC9 /* BlueshiftLog.m in Sources */,
 				55BD2C021D9172F300422869 /* BlueShiftRequestQueue.m in Sources */,
 				55BD2C001D9172F300422869 /* BlueShiftRequestOperation.m in Sources */,
 				555A39AF1ECDA8030067D21C /* BlueShiftCarousalViewController.m in Sources */,

--- a/BlueShift-iOS-SDK/BatchEventEntity.m
+++ b/BlueShift-iOS-SDK/BatchEventEntity.m
@@ -6,6 +6,7 @@
 //
 
 #import "BatchEventEntity.h"
+#import "BlueshiftLog.h"
 
 @interface BatchEventEntity ()
 
@@ -27,7 +28,7 @@
             masterContext = appDelegate.batchEventManagedObjectContext;
         }
         @catch (NSException *exception) {
-            NSLog(@"Caught exception %@", exception);
+            [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
         }
     }
     if (masterContext) {
@@ -60,7 +61,7 @@
             }
         }
         @catch (NSException *exception) {
-            NSLog(@"Caught exception %@", exception);
+            [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
         }
     } else {
         return ;
@@ -78,7 +79,7 @@
                 context = appDelegate.batchEventManagedObjectContext;
             }
             @catch (NSException *exception) {
-                NSLog(@"Caught exception %@", exception);
+                [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
             }
             if(context) {
                 NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] init];
@@ -86,7 +87,7 @@
                     [fetchRequest setEntity:[NSEntityDescription entityForName:@"BatchEventEntity" inManagedObjectContext:context]];
                 }
                 @catch (NSException *exception) {
-                    NSLog(@"Caught exception %@", exception);
+                    [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
                 }
                 if(fetchRequest.entity != nil) {
                     [BatchEventEntity fetchBatchesFromCoreDataFromContext:context request:fetchRequest handler:handler];
@@ -121,7 +122,7 @@
         }
     }
     @catch (NSException *exception) {
-        NSLog(@"Caught exception %@", exception);
+        [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
     }
 }
 

--- a/BlueShift-iOS-SDK/BlueShift.m
+++ b/BlueShift-iOS-SDK/BlueShift.m
@@ -733,13 +733,12 @@ static BlueShift *_sharedBlueShiftInstance = nil;
                 [BlueshiftInAppNotificationRequest fetchInAppNotification: notificationID andLastTimestamp:lastTimestamp success:^(NSDictionary *dictionary){
                     if ([dictionary objectForKey: kInAppNotificationContentPayloadKey]) {
                         NSMutableArray *notificationArray = [dictionary objectForKey: kInAppNotificationContentPayloadKey];
-                        [BlueshiftLog logInfo:@"Succesfully fetched in-app messages." withDetails:dictionary methodName:nil];
                         [_inAppNotificationMananger initializeInAppNotificationFromAPI:notificationArray handler:^(BOOL status) {
                             success();
                         }];
                     }
                 } failure:^(NSError *error){
-                    [BlueshiftLog logError:error withDescription:[NSString stringWithFormat:@"Failed to fetch in-app messages details."] methodName: [NSString stringWithUTF8String: __PRETTY_FUNCTION__]];
+                    failure(error);
                 }];
             } else {
                 NSError *error = (NSError *)@"Unable to fetch the data from core data.";

--- a/BlueShift-iOS-SDK/BlueShift.m
+++ b/BlueShift-iOS-SDK/BlueShift.m
@@ -9,6 +9,7 @@
 #import <UserNotifications/UserNotifications.h>
 #import "BlueShiftInAppNotificationManager.h"
 #import "BlueShiftNotificationConstants.h"
+#import "BlueshiftLog.h"
 
 BlueShiftAppDelegate *_newDelegate;
 BlueShiftInAppNotificationManager *_inAppNotificationMananger;
@@ -125,15 +126,12 @@ static BlueShift *_sharedBlueShiftInstance = nil;
         
         [self fetchInAppNotificationFromAPI:^(void) {
             [self fetchInAppNotificationFromDB];
-        } failure:^(NSError *error){
-            NSLog(@"%@", error);
-        }];
+        } failure:^(NSError *error){ }];
     }
-    
     //Mark app open
     [blueShiftAppDelegate trackAppOpenWithParameters:nil];
-    
-    [BlueShiftNetworkReachabilityManager monitorNetworkConnectivity];
+
+    [BlueshiftLog logInfo:@"SDK configured successfully. Below are the config details" withDetails:[config getConfigStringToLog] methodName:nil];
 }
 
 - (void)initDeepLinks {
@@ -178,15 +176,14 @@ static BlueShift *_sharedBlueShiftInstance = nil;
 }
 
 - (void) createInAppNotification:(NSDictionary *)dictionary forApplicationState:(UIApplicationState)applicationState {
+    [BlueshiftLog logInfo:@"Silent push notification received - " withDetails:dictionary methodName:nil];
     if (_config.enableInAppNotification == YES) {
         if ([BlueshiftEventAnalyticsHelper isFetchInAppAction: dictionary] && _config.inAppBackgroundFetchEnabled == YES) {
             [self fetchInAppNotificationFromAPI:^() {
                 if (self->_config.inAppManualTriggerEnabled == NO) {
                          [self fetchInAppNotificationFromDB];
                     }
-                } failure:^(NSError *error){
-                    NSLog(@"%@", error);
-            }];
+                } failure:^(NSError *error){ }];
         } else if ([BlueshiftEventAnalyticsHelper isMarkInAppAsOpen:dictionary]) {
             if (_inAppNotificationMananger) {
                 NSDictionary *silentPushData = [[dictionary objectForKey: kSilentNotificationPayloadIdentifierKey] objectForKey: kInAppNotificationModalSilentPushKey];
@@ -539,7 +536,8 @@ static BlueShift *_sharedBlueShiftInstance = nil;
     BlueShiftSubscription *subscription = [BlueShiftSubscription currentSubscription];
     
     if (subscription==nil) {
-        NSLog(@"\n\n Error: Could not pause subscription. Please initialize the subscription \n\n");
+        [BlueshiftLog logError:nil withDescription:[NSString stringWithFormat:@"Could not pause subscription. Please initialize the subscription"] methodName:nil];
+
         return ;
     }
     
@@ -566,7 +564,7 @@ static BlueShift *_sharedBlueShiftInstance = nil;
     BlueShiftSubscription *subscription = [BlueShiftSubscription currentSubscription];
     
     if (subscription==nil) {
-        NSLog(@"\n\n Error: Could not unpause subscription. Please initialize the subscription \n\n");
+        [BlueshiftLog logError:nil withDescription:[NSString stringWithFormat:@"Could not unpause subscription. Please initialize the subscription"] methodName:nil];
         return ;
     }
     
@@ -592,7 +590,7 @@ static BlueShift *_sharedBlueShiftInstance = nil;
     BlueShiftSubscription *subscription = [BlueShiftSubscription currentSubscription];
     
     if (subscription==nil) {
-        NSLog(@"\n\n Error: Could not cancel subscription. Please initialize the subscription \n\n");
+        [BlueshiftLog logError:nil withDescription:[NSString stringWithFormat:@"Could not cancel subscription. Please initialize the subscription"] methodName:nil];
         return ;
     }
     
@@ -637,7 +635,7 @@ static BlueShift *_sharedBlueShiftInstance = nil;
     [requestMutableParameters addEntriesFromDictionary:[BlueShiftDeviceData currentDeviceData].toDictionary];
     [requestMutableParameters addEntriesFromDictionary:[BlueShiftAppData currentAppData].toDictionary];
     if ([BlueShiftUserInfo sharedInstance]==nil) {
-        NSLog(@"\n\n BlueShift Warning: Please set BlueShiftUserInfo for sending retailer customer ID, email and so on.");
+        [BlueshiftLog logInfo:[NSString stringWithFormat:@"Please set BlueshiftUserInfo for sending the user attributes such as email id, customer id"] withDetails:nil methodName:nil];
     }
     else {
         NSString *email = [requestMutableParameters objectForKey:@"email"];
@@ -735,17 +733,17 @@ static BlueShift *_sharedBlueShiftInstance = nil;
                 [BlueshiftInAppNotificationRequest fetchInAppNotification: notificationID andLastTimestamp:lastTimestamp success:^(NSDictionary *dictionary){
                     if ([dictionary objectForKey: kInAppNotificationContentPayloadKey]) {
                         NSMutableArray *notificationArray = [dictionary objectForKey: kInAppNotificationContentPayloadKey];
+                        [BlueshiftLog logInfo:@"Succesfully fetched in-app messages." withDetails:dictionary methodName:nil];
                         [_inAppNotificationMananger initializeInAppNotificationFromAPI:notificationArray handler:^(BOOL status) {
                             success();
                         }];
                     }
                 } failure:^(NSError *error){
-                    NSLog(@"InApp Message API failed");
-                    failure(error);
+                    [BlueshiftLog logError:error withDescription:[NSString stringWithFormat:@"Failed to fetch in-app messages details."] methodName: [NSString stringWithUTF8String: __PRETTY_FUNCTION__]];
                 }];
             } else {
-                NSLog(@"Unable to fetch the data from core data");
-                NSError *error = (NSError *)@"Unable to fetch the data from core data";
+                NSError *error = (NSError *)@"Unable to fetch the data from core data.";
+                [BlueshiftLog logError:error withDescription:nil methodName: [NSString stringWithUTF8String: __PRETTY_FUNCTION__]];
                 failure(error);
             }
         }];

--- a/BlueShift-iOS-SDK/BlueShiftAlertView.m
+++ b/BlueShift-iOS-SDK/BlueShiftAlertView.m
@@ -11,13 +11,13 @@
 
 - (UIAlertController *)alertViewWithPushDetailsDictionary:(NSDictionary *)pushDetailsDictionary  API_AVAILABLE(ios(8.0)){
     
-    NSDictionary *pushAlertDictionary = [pushDetailsDictionary objectForKey:@"aps"];
-    NSString *pushCategory = [[pushDetailsDictionary objectForKey:@"aps"] objectForKey:@"category"];
-    NSString *pushTitle = [[pushAlertDictionary objectForKey:@"alert"] objectForKey:@"title"];
+    NSDictionary *pushAlertDictionary = [pushDetailsDictionary objectForKey:kNotificationAPSIdentifierKey];
+    NSString *pushCategory = [pushAlertDictionary objectForKey:kNotificationCategoryIdentifierKey];
+    NSString *pushTitle = [[pushAlertDictionary objectForKey: kNotificationAlertIdentifierKey] objectForKey:kNotificationTitleKey];
     if (!pushTitle || [pushTitle isEqualToString:@""]) {
         pushTitle = kAlertTitle;
     }
-    NSString *pushMessage = [[pushAlertDictionary objectForKey:@"alert"] objectForKey:@"body"];
+    NSString *pushMessage = [[pushAlertDictionary objectForKey:kNotificationAlertIdentifierKey] objectForKey:kNotificationBodyKey];
     UIAlertController *blueShiftAlertController = [UIAlertController alertControllerWithTitle:pushTitle message:pushMessage  preferredStyle:UIAlertControllerStyleAlert];
     if ([pushCategory isEqualToString:kNotificationCategoryBuyIdentifier]) {
         UIAlertAction *dismissAction = [UIAlertAction actionWithTitle:kDismissButton style:UIAlertActionStyleCancel handler:nil];

--- a/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
+++ b/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
@@ -85,7 +85,7 @@
     } else {
         // Fallback on earlier versions
     }
-    
+
     NSString *deviceTokenString = [self hexadecimalStringFromData: deviceToken];
     deviceTokenString = [deviceTokenString stringByReplacingOccurrencesOfString:@" " withString:@""];
     [BlueShiftDeviceData currentDeviceData].deviceToken = deviceTokenString;

--- a/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
+++ b/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
@@ -10,6 +10,7 @@
 #import "BlueShiftHttpRequestBatchUpload.h"
 #import "BlueShiftInAppNotificationManager.h"
 #import "BlueShiftInAppNotificationConstant.h"
+#import "BlueshiftLog.h"
 
 #define SYSTEM_VERSION_GRATERTHAN_OR_EQUALTO(v) ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedAscending)
 
@@ -84,11 +85,12 @@
     } else {
         // Fallback on earlier versions
     }
-
+    
     NSString *deviceTokenString = [self hexadecimalStringFromData: deviceToken];
     deviceTokenString = [deviceTokenString stringByReplacingOccurrencesOfString:@" " withString:@""];
     [BlueShiftDeviceData currentDeviceData].deviceToken = deviceTokenString;
-    NSString *previousDeviceToken = [[BlueShift sharedInstance] getDeviceToken];
+    [BlueshiftLog logInfo:[NSString stringWithFormat:@"Successfully registered for remote notifications. Device token: "] withDetails:deviceTokenString methodName:nil];
+     NSString *previousDeviceToken = [[BlueShift sharedInstance] getDeviceToken];
     if (previousDeviceToken && deviceTokenString) {
         if(![previousDeviceToken isEqualToString:deviceTokenString]) {
             [self fireIdentifyCall];
@@ -128,7 +130,7 @@
 }
 
 - (void) failedToRegisterForRemoteNotificationWithError:(NSError *)error {
-    NSLog(@"\n\n Failed to get push token, error: %@ \n\n", error);
+    [BlueshiftLog logError:error withDescription:[NSString stringWithFormat:@"Failed to register for remote notification"] methodName:nil];
     NSDictionary *userInfo =
     [NSDictionary dictionaryWithObject:@NO forKey:[[[BlueShift sharedInstance] config] isEnabledPushNotificationKey]];
     [[NSNotificationCenter defaultCenter] postNotificationName:
@@ -1029,7 +1031,7 @@
         error = [NSError errorWithDomain:@"YOUR_ERROR_DOMAIN" code:9999 userInfo:dict];
         // Replace this with code to handle the error appropriately.
         // abort() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-        NSLog(@"Unresolved error %@, %@", error, [error userInfo]);
+        [BlueshiftLog logError:error withDescription:@"Unresolved error" methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
     }
     
     return _persistentStoreCoordinator;
@@ -1089,7 +1091,7 @@
         if ([managedObjectContext hasChanges] && ![managedObjectContext save:&error]) {
             // Replace this implementation with code to handle the error appropriately.
             // abort() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-            NSLog(@"Unresolved error %@, %@", error, [error userInfo]);
+            [BlueshiftLog logError:error withDescription:@"Unresolved error" methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
         }
     }
 }
@@ -1161,7 +1163,7 @@
             }
         }
     } @catch (NSException *exception) {
-        NSLog(@"Caught exception %@", exception);
+        [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
     }
 }
 

--- a/BlueShift-iOS-SDK/BlueShiftConfig.h
+++ b/BlueShift-iOS-SDK/BlueShiftConfig.h
@@ -32,6 +32,7 @@
 @property BOOL enableInAppNotification;
 @property BOOL inAppManualTriggerEnabled;
 @property BOOL inAppBackgroundFetchEnabled;
+@property BOOL debug;
 
 @property NSSet * _Nullable customCategories;
 
@@ -48,6 +49,7 @@
 @property (nonatomic, assign) BlueshiftDeviceIdSource blueshiftDeviceIdSource;
 
 - (BOOL)validateConfigDetails;
+- (NSString*_Nullable)getConfigStringToLog;
 
 + (BlueShiftConfig * _Nonnull )config;
 @end

--- a/BlueShift-iOS-SDK/BlueShiftConfig.m
+++ b/BlueShift-iOS-SDK/BlueShiftConfig.m
@@ -6,6 +6,8 @@
 //
 
 #import "BlueShiftConfig.h"
+#import "BlueshiftLog.h"
+#import <objc/runtime.h>
 
 @implementation BlueShiftConfig
 
@@ -18,6 +20,8 @@
         self.enableAppOpenTrackEvent = YES;
         self.blueShiftNotificationName = @"BlueShiftPushNotificationSetting";
         self.isEnabledPushNotificationKey = @"isEnabled";
+        
+        self.debug = NO;
         
         //In App
         self.enableInAppNotification = NO;
@@ -39,10 +43,23 @@
     
     if (self.apiKey == NULL || self.apiKey == nil) {
         status = NO;
-        NSLog(@"\n\n Cannot initialize the SDK. Need to set the API Key. \n\n");
+        [BlueshiftLog logError:nil withDescription:@"Failed to initialize the SDK, API Key is required to initialise the SDK. Set API key in Blueshift config." methodName:nil];
     }
     
     return status;
+}
+
+- (NSString*_Nullable)getConfigStringToLog {
+    unsigned int numberOfProperties = 0;
+    NSString *configString = @"";
+    objc_property_t *propertyArray = class_copyPropertyList([self class], &numberOfProperties);
+    for (NSUInteger i = 0; i < numberOfProperties; i++) {
+        objc_property_t property = propertyArray[i];
+        NSString *name = [[NSString alloc] initWithUTF8String:property_getName(property)];
+        configString = [NSString stringWithFormat:@"%@ %@ : %@\n", configString, name, [self valueForKey:name]];
+    }
+    free(propertyArray);
+    return configString;
 }
 
 @end

--- a/BlueShift-iOS-SDK/BlueShiftConfig.m
+++ b/BlueShift-iOS-SDK/BlueShiftConfig.m
@@ -43,7 +43,7 @@
     
     if (self.apiKey == NULL || self.apiKey == nil) {
         status = NO;
-        [BlueshiftLog logError:nil withDescription:@"Failed to initialize the SDK, API Key is required to initialise the SDK. Set API key in Blueshift config." methodName:nil];
+        [BlueshiftLog logError:nil withDescription:@"SDK initialization failed! Please set a valid API key inside the Blueshift config to initialize the SDK." methodName:nil];
     }
     
     return status;

--- a/BlueShift-iOS-SDK/BlueShiftDeepLink.m
+++ b/BlueShift-iOS-SDK/BlueShiftDeepLink.m
@@ -5,6 +5,7 @@
 //  Copyright (c) Blueshift. All rights reserved.
 //
 #import "BlueShiftDeepLink.h"
+#import "BlueshiftLog.h"
 
 @implementation BlueShiftDeepLink
 
@@ -89,7 +90,7 @@ static NSDictionary *_deepLinkList = nil;
     
     UINavigationController *navController = (UINavigationController *)[[[UIApplication sharedApplication] delegate] window].rootViewController;
     if(navController == nil) {
-        NSLog(@"rootViewContoller is nil");
+        [BlueshiftLog logError:nil withDescription:@"Can not perform custom deep linking as rootViewContoller is nil" methodName:nil];
         return NO;
     }
     

--- a/BlueShift-iOS-SDK/BlueShiftDeviceData.m
+++ b/BlueShift-iOS-SDK/BlueShiftDeviceData.m
@@ -44,7 +44,7 @@ static BlueShiftDeviceData *_currentDeviceData = nil;
             if (bundleId != nil) {
                 deviceUUID = [NSString stringWithFormat:@"%@:%@", self.deviceIDFV,bundleId];
             } else {
-                [BlueshiftLog logError:nil withDescription:@"Failed to get the bundle Id. Use different DeviceIdSource." methodName:nil];
+                [BlueshiftLog logError:nil withDescription:@"Failed to get the bundle Id." methodName:nil];
             }
         }
             break;

--- a/BlueShift-iOS-SDK/BlueShiftDeviceData.m
+++ b/BlueShift-iOS-SDK/BlueShiftDeviceData.m
@@ -6,6 +6,7 @@
 //
 #import "BlueShiftDeviceData.h"
 #import "BlueShift.h"
+#import "BlueshiftLog.h"
 
 static BlueShiftDeviceData *_currentDeviceData = nil;
 
@@ -43,7 +44,7 @@ static BlueShiftDeviceData *_currentDeviceData = nil;
             if (bundleId != nil) {
                 deviceUUID = [NSString stringWithFormat:@"%@:%@", self.deviceIDFV,bundleId];
             } else {
-                NSLog(@"[BlueShift] - ERROR: Failed to get the bundle Id");
+                [BlueshiftLog logError:nil withDescription:@"Failed to get the bundle Id. Use different DeviceIdSource." methodName:nil];
             }
         }
             break;

--- a/BlueShift-iOS-SDK/BlueShiftHttpRequestBatchUpload.m
+++ b/BlueShift-iOS-SDK/BlueShiftHttpRequestBatchUpload.m
@@ -6,6 +6,7 @@
 //
 
 #import "BlueShiftHttpRequestBatchUpload.h"
+#import "BlueshiftLog.h"
 
 #define kBatchSize  100
 
@@ -76,7 +77,7 @@ static BlueShiftRequestQueueStatus _requestQueueStatus = BlueShiftRequestQueueSt
                         masterContext = appDelegate.batchEventManagedObjectContext;
                     }
                     @catch (NSException *exception) {
-                        NSLog(@"Caught exception %@", exception);
+                        [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
                     }
                 }
                 if(masterContext) {
@@ -107,7 +108,7 @@ static BlueShiftRequestQueueStatus _requestQueueStatus = BlueShiftRequestQueueSt
                         }
                     }
                     @catch (NSException *exception) {
-                        NSLog(@"Caught exception %@", exception);
+                        [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
                     }
                 }
             }
@@ -129,7 +130,7 @@ static BlueShiftRequestQueueStatus _requestQueueStatus = BlueShiftRequestQueueSt
         }
     }
     @catch (NSException *exception) {
-        NSLog(@"Caught exception %@", exception);
+        [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
     }
 }
 
@@ -176,7 +177,7 @@ static BlueShiftRequestQueueStatus _requestQueueStatus = BlueShiftRequestQueueSt
                     context = appDelegate.batchEventManagedObjectContext;
                 }
                 @catch (NSException *exception) {
-                    NSLog(@"Caught exception %@", exception);
+                    [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
                 }
                 if(context != nil) {
                     // Only handles when the fetched record is not nil ...
@@ -221,7 +222,7 @@ static BlueShiftRequestQueueStatus _requestQueueStatus = BlueShiftRequestQueueSt
         }
     }
     @catch (NSException *exception) {
-        NSLog(@"Caught exception %@", exception);
+        [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
     }
     handler(YES);
 }
@@ -252,7 +253,7 @@ static BlueShiftRequestQueueStatus _requestQueueStatus = BlueShiftRequestQueueSt
         }
     }
     @catch (NSException *exception) {
-        NSLog(@"Caught exception %@", exception);
+        [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
     }
     handler(NO);
 }

--- a/BlueShift-iOS-SDK/BlueShiftLiveContent.m
+++ b/BlueShift-iOS-SDK/BlueShiftLiveContent.m
@@ -8,6 +8,7 @@
 
 #import "BlueShiftLiveContent.h"
 #import "BlueShiftRequestOperationManager.h"
+#import "BlueshiftLog.h"
 
 @implementation BlueShiftLiveContent
 
@@ -29,8 +30,8 @@
             }
         }];
     } else {
-        NSLog(@"Email is not set");
-        NSError *error = (NSError*)@"Email ID not set";
+        NSError *error = (NSError*)@"Email id is required to fetch live content by email. Set emailId in BlueshiftUserInfo";
+        [BlueshiftLog logError:error withDescription:nil methodName:nil];
         failure(error);
     }
 }
@@ -53,8 +54,8 @@
             }
         }];
     } else {
-        NSLog(@"Customer ID is not set");
-        NSError *error = (NSError*)@"Customer ID not set";
+        NSError *error = (NSError*)@"Customer id is required to fetch live content by email. Set customerId in BlueshiftUserInfo";
+        [BlueshiftLog logError:error withDescription:nil methodName:nil];
         failure(error);
     }
 }
@@ -77,8 +78,8 @@
             }
         }];
     } else {
-        NSLog(@"Device ID is not there");
-        NSError *error = (NSError*)@"Device ID not set";
+        NSError *error = (NSError*)@"Device id is required to fetch live content by deviceId.";
+        [BlueshiftLog logError:error withDescription:nil methodName:nil];
         failure(error);
     }
 }
@@ -108,8 +109,8 @@
             }
         }];
     } else {
-        NSLog(@"Email is not set");
-        NSError *error = (NSError*)@"Email ID not set";
+        NSError *error = (NSError*)@"Email id is required to fetch live content by email. Set emailId in BlueshiftUserInfo";
+        [BlueshiftLog logError:error withDescription:nil methodName:nil];
         failure(error);
     }
 }
@@ -139,9 +140,9 @@
             }
         }];
     } else {
-        NSLog(@"Customer ID is not set");
-        NSError *error = (NSError*)@"Customer ID not set";
-        failure(error); 
+        NSError *error = (NSError*)@"Customer id is required to fetch live content by email. Set customerId in BlueshiftUserInfo";
+        [BlueshiftLog logError:error withDescription:nil methodName:nil];
+        failure(error);
     }
 }
 
@@ -170,8 +171,8 @@
             }
         }];
     } else {
-        NSLog(@"Device ID is not there");
-        NSError *error = (NSError*)@"Device ID not set";
+        NSError *error = (NSError*)@"Device id is required to fetch live content by deviceId.";
+        [BlueshiftLog logError:error withDescription:nil methodName:nil];
         failure(error);
     }
 }

--- a/BlueShift-iOS-SDK/BlueShiftNetworkReachabilityManager.m
+++ b/BlueShift-iOS-SDK/BlueShiftNetworkReachabilityManager.m
@@ -12,11 +12,6 @@
 
 @implementation BlueShiftNetworkReachabilityManager
 
-// Method to start monitoring network connectivity ...
-+ (void)monitorNetworkConnectivity {
-
-}
-
 // Method to check whether internet is connected ...
 + (BOOL)networkConnected {
     BlueShiftReachability *reach = [BlueShiftReachability reachabilityWithHostName:@"www.google.com"];

--- a/BlueShift-iOS-SDK/BlueShiftNotificationConstants.h
+++ b/BlueShift-iOS-SDK/BlueShiftNotificationConstants.h
@@ -15,6 +15,8 @@
 #define kNotificationTypeIdentifierKey                                  @"notification_type"
 #define kNotificationKey                                                @"notification"
 #define kNotificationCarouselElementIdentifierKey                       @"carousel_elements"
+#define kNotificationBodyKey                                            @"body"
+#define kNotificationTitleKey                                           @"title"
 
 #define kNotificationCategoryBuyIdentifier                              @"buy"
 #define kNotificationActionBuyIdentifier                                @"buy"

--- a/BlueShift-iOS-SDK/BlueShiftRequestOperationManager.m
+++ b/BlueShift-iOS-SDK/BlueShiftRequestOperationManager.m
@@ -146,7 +146,7 @@ static BlueShiftRequestOperationManager *_sharedRequestOperationManager = nil;
     }
     NSMutableURLRequest *urlRequest = [[NSMutableURLRequest alloc] initWithURL: url];
     [urlRequest setHTTPMethod:@"GET"];
-    [BlueshiftLog logAPICallInfo:[NSString stringWithFormat:@"Initiated ULReplay for - %@", url.absoluteString] withDetails:nil statusCode:nil];
+    [BlueshiftLog logAPICallInfo:[NSString stringWithFormat:@"Initiated ULReplay for - %@", url.absoluteString] withDetails:nil statusCode:0];
     NSURLSessionDataTask *dataTask = [_replayURLSesion dataTaskWithRequest:urlRequest completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
         if(error == nil)

--- a/BlueShift-iOS-SDK/BlueShiftRequestOperationManager.m
+++ b/BlueShift-iOS-SDK/BlueShiftRequestOperationManager.m
@@ -146,20 +146,21 @@ static BlueShiftRequestOperationManager *_sharedRequestOperationManager = nil;
     }
     NSMutableURLRequest *urlRequest = [[NSMutableURLRequest alloc] initWithURL: url];
     [urlRequest setHTTPMethod:@"GET"];
+    [BlueshiftLog logAPICallInfo:[NSString stringWithFormat:@"Initiated ULReplay for - %@", url.absoluteString] withDetails:nil statusCode:nil];
     NSURLSessionDataTask *dataTask = [_replayURLSesion dataTaskWithRequest:urlRequest completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
         if(error == nil)
         {
             if(httpResponse.URL != nil)
             {
-                [BlueshiftLog logAPICallInfo:[NSString stringWithFormat:@"ULReplay - Success %@", httpResponse.URL] withDetails:nil statusCode:httpResponse.statusCode];
+                [BlueshiftLog logAPICallInfo:[NSString stringWithFormat:@"ULReplay - Success %@", [[httpResponse URL] absoluteString]] withDetails:nil statusCode:httpResponse.statusCode];
                 handler(YES, httpResponse.URL, nil);
             } else {
-                [BlueshiftLog logAPICallInfo:[NSString stringWithFormat:@"ULReplay - Fail %@", httpResponse.URL] withDetails:nil statusCode:httpResponse.statusCode];
+                [BlueshiftLog logAPICallInfo:[NSString stringWithFormat:@"ULReplay - Fail %@", [[httpResponse URL] absoluteString]] withDetails:nil statusCode:httpResponse.statusCode];
                 handler(NO,nil,[NSError errorWithDomain:@"Failed to load redirection link" code:httpResponse.statusCode userInfo:nil]);
             }
         } else {
-            [BlueshiftLog logAPICallInfo:[NSString stringWithFormat:@"ULReplay - Fail %@",httpResponse.URL] withDetails:nil statusCode:httpResponse.statusCode];
+            [BlueshiftLog logAPICallInfo:[NSString stringWithFormat:@"ULReplay - Fail %@",[[httpResponse URL] absoluteString]] withDetails:nil statusCode:httpResponse.statusCode];
             handler(NO,nil,error);
         }
     }];

--- a/BlueShift-iOS-SDK/BlueShiftRequestQueue.m
+++ b/BlueShift-iOS-SDK/BlueShiftRequestQueue.m
@@ -6,6 +6,7 @@
 //
 
 #import "BlueShiftRequestQueue.h"
+#import "BlueshiftLog.h"
 
 @interface BlueShiftRequestQueue ()
 
@@ -32,7 +33,7 @@ static BlueShiftRequestQueueStatus _requestQueueStatus = BlueShiftRequestQueueSt
                     masterContext = appDelegate.managedObjectContext;
                 }
                 @catch (NSException *exception) {
-                    NSLog(@"Caught exception %@", exception);
+                    [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
                 }
             }
             if(masterContext) {
@@ -41,7 +42,7 @@ static BlueShiftRequestQueueStatus _requestQueueStatus = BlueShiftRequestQueueSt
                     entity = [NSEntityDescription entityForName:@"HttpRequestOperationEntity" inManagedObjectContext:masterContext];
                 }
                 @catch (NSException *exception) {
-                    NSLog(@"Caught exception %@", exception);
+                    [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
                 }
                 if(entity != nil) {
                     NSString *url = requestOperation.url;
@@ -72,7 +73,7 @@ static BlueShiftRequestQueueStatus _requestQueueStatus = BlueShiftRequestQueueSt
                             }
                         }
                     } @catch (NSException *exception) {
-                        NSLog(@"Caught exception %@", exception);
+                        [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
                     }
                 }
             }
@@ -89,7 +90,7 @@ static BlueShiftRequestQueueStatus _requestQueueStatus = BlueShiftRequestQueueSt
                 context = appDelegate.batchEventManagedObjectContext;
             }
             @catch (NSException *exception) {
-                NSLog(@"Caught exception %@", exception);
+                [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
             }
         }
         if(context) {
@@ -98,7 +99,7 @@ static BlueShiftRequestQueueStatus _requestQueueStatus = BlueShiftRequestQueueSt
                 entity = [NSEntityDescription entityForName:@"BatchEventEntity" inManagedObjectContext:context];
             }
             @catch (NSException *exception) {
-                NSLog(@"Caught exception %@", exception);
+                [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
             }
             if(entity != nil) {
                 NSArray *paramsArray = requestOperation.paramsArray;
@@ -172,7 +173,7 @@ static BlueShiftRequestQueueStatus _requestQueueStatus = BlueShiftRequestQueueSt
                 }
             }
             @catch (NSException *exception) {
-                NSLog(@"Caught exception %@", exception);
+                [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
                 _requestQueueStatus = BlueShiftRequestQueueStatusAvailable;
                 [self processRequestsInQueue];
             }
@@ -203,7 +204,7 @@ static BlueShiftRequestQueueStatus _requestQueueStatus = BlueShiftRequestQueueSt
         }
     }
     @catch (NSException *exception) {
-        NSLog(@"Caught exception %@", exception);
+        [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
         [self processRequestsInQueue];
     }
 }
@@ -235,7 +236,7 @@ static BlueShiftRequestQueueStatus _requestQueueStatus = BlueShiftRequestQueueSt
         }
     }
     @catch (NSException *exception) {
-        NSLog(@"Caught exception %@", exception);
+        [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
         [self processRequestsInQueue];
     }
 }
@@ -257,7 +258,7 @@ static BlueShiftRequestQueueStatus _requestQueueStatus = BlueShiftRequestQueueSt
                         context = appDelegate.realEventManagedObjectContext;
                     }
                     @catch (NSException *exception) {
-                        NSLog(@"Caught exception %@", exception);
+                        [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
                     }
                     [self processRequestsWithContext:context forEntity:operationEntityToBeExecuted];
                 } else {

--- a/BlueShift-iOS-SDK/BlueShiftUserInfo.m
+++ b/BlueShift-iOS-SDK/BlueShiftUserInfo.m
@@ -6,10 +6,14 @@
 //
 
 #import "BlueShiftUserInfo.h"
+#import "BlueshiftLog.h"
 
 static BlueShiftUserInfo *_sharedUserInfo = nil;
 
-@implementation BlueShiftUserInfo
+@implementation BlueShiftUserInfo {
+    BOOL isCustomerIdNotSetInfoDisplayed;
+    BOOL isEmailIdNotSetInfoDisplayed;
+}
 
 + (instancetype) sharedInstance {
     static dispatch_once_t onceToken;
@@ -29,9 +33,10 @@ static BlueShiftUserInfo *_sharedUserInfo = nil;
     if (self.email) {
         [sharedUserInfoMutableDictionary setObject:self.email forKey:@"email"];
     } else {
-        #ifdef DEBUG
-            NSLog(@"\n\n BlueShiftWarning: Email not set for BlueShiftUserInfo \n");
-        #endif
+        if (!isEmailIdNotSetInfoDisplayed) {
+            [BlueshiftLog logInfo:@"EmailId is not set for BlueShiftUserInfo. Please set email id." withDetails:nil methodName:nil];
+            isEmailIdNotSetInfoDisplayed = YES;
+        }
     }
     
     if (self.name) {
@@ -41,9 +46,10 @@ static BlueShiftUserInfo *_sharedUserInfo = nil;
     if (self.retailerCustomerID) {
         [sharedUserInfoMutableDictionary setObject:self.retailerCustomerID forKey:@"customer_id"];
     } else {
-        #ifdef DEBUG
-            NSLog(@"\n\n BlueShiftWarning: Retailer Customer ID not set for BlueShiftUserInfo \n");
-        #endif
+        if (!isCustomerIdNotSetInfoDisplayed) {
+            [BlueshiftLog logInfo:@"Retails customer ID is not set for BlueShiftUserInfo. Please set customer Id" withDetails:nil methodName:nil];
+            isCustomerIdNotSetInfoDisplayed = YES;
+        }
     }
     
     if (self.firstName) {

--- a/BlueShift-iOS-SDK/BlueShiftUserNotificationCenterDelegate.m
+++ b/BlueShift-iOS-SDK/BlueShiftUserNotificationCenterDelegate.m
@@ -6,6 +6,7 @@
 //
 
 #import "BlueShiftUserNotificationCenterDelegate.h"
+#import "BlueshiftLog.h"
 
 @implementation BlueShiftUserNotificationCenterDelegate
 
@@ -18,8 +19,10 @@
 - (void)handleUserNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler API_AVAILABLE(ios(10.0)){
     NSDictionary *userInfo = notification.request.content.userInfo;
     if([[userInfo objectForKey:kNotificationTypeIdentifierKey] isEqualToString:kNotificationKey]) {
+        [BlueshiftLog logInfo:@"Push Notification received" withDetails:userInfo methodName:nil];
         completionHandler(UNAuthorizationOptionSound | UNAuthorizationOptionAlert | UNAuthorizationOptionBadge);
     } else if([[userInfo objectForKey:kNotificationTypeIdentifierKey] isEqualToString:kNotificationAlertIdentifierKey]) {
+        [BlueshiftLog logInfo:@"Dialog box Push Notification received" withDetails:userInfo methodName:nil];
         [[BlueShift sharedInstance].appDelegate presentInAppAlert:notification.request.content.userInfo];
     }
 }

--- a/BlueShift-iOS-SDK/BlueshiftEventAnalyticsHelper.m
+++ b/BlueShift-iOS-SDK/BlueshiftEventAnalyticsHelper.m
@@ -10,6 +10,7 @@
 #import "BlueShiftAppData.h"
 #import "BlueShiftInAppNotificationHelper.h"
 #import "BlueShiftInAppNotificationConstant.h"
+#import "BlueshiftLog.h"
 
 @implementation BlueshiftEventAnalyticsHelper
 
@@ -154,7 +155,7 @@
         
         return queryDictionary;
     } @catch (NSException *exception) {
-        NSLog(@"Caught exception %@", exception);
+        [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
     }
 }
 

--- a/BlueShift-iOS-SDK/BlueshiftLog.h
+++ b/BlueShift-iOS-SDK/BlueshiftLog.h
@@ -1,0 +1,18 @@
+//
+//  BlueshiftLog.h
+//  BlueShift-iOS-SDK
+//
+//  Created by Ketan Shikhare on 29/07/20.
+//  Copyright © 2020 Bullfinch Software. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface BlueshiftLog : NSObject
+
++ (void)logError:(NSError*) error withDescription:(NSString*)description methodName:(NSString*)method;
++ (void)logException:(NSException*) exception withDescription:(NSString*)description methodName:(NSString*)method;
++ (void)logInfo:(NSString*)info withDetails: (id) details methodName:(NSString*)method;
++(void)logAPICallInfo:(NSString*)info withDetails: (NSDictionary*) details statusCode:(NSInteger)statusCode;
+
+@end

--- a/BlueShift-iOS-SDK/BlueshiftLog.h
+++ b/BlueShift-iOS-SDK/BlueshiftLog.h
@@ -3,7 +3,7 @@
 //  BlueShift-iOS-SDK
 //
 //  Created by Ketan Shikhare on 29/07/20.
-//  Copyright © 2020 Bullfinch Software. All rights reserved.
+//  Copyright © 2020 Blueshift. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
@@ -13,6 +13,6 @@
 + (void)logError:(NSError*) error withDescription:(NSString*)description methodName:(NSString*)method;
 + (void)logException:(NSException*) exception withDescription:(NSString*)description methodName:(NSString*)method;
 + (void)logInfo:(NSString*)info withDetails: (id) details methodName:(NSString*)method;
-+(void)logAPICallInfo:(NSString*)info withDetails: (NSDictionary*) details statusCode:(NSInteger)statusCode;
++ (void)logAPICallInfo:(NSString*)info withDetails: (NSDictionary*) details statusCode:(NSInteger)statusCode;
 
 @end

--- a/BlueShift-iOS-SDK/BlueshiftLog.m
+++ b/BlueShift-iOS-SDK/BlueshiftLog.m
@@ -3,7 +3,7 @@
 //  BlueShift-iOS-SDK
 //
 //  Created by Ketan Shikhare on 29/07/20.
-//  Copyright © 2020 Bullfinch Software. All rights reserved.
+//  Copyright © 2020 Blueshift. All rights reserved.
 //
 
 #import "BlueshiftLog.h"

--- a/BlueShift-iOS-SDK/BlueshiftLog.m
+++ b/BlueShift-iOS-SDK/BlueshiftLog.m
@@ -1,0 +1,96 @@
+//
+//  BlueshiftLog.m
+//  BlueShift-iOS-SDK
+//
+//  Created by Ketan Shikhare on 29/07/20.
+//  Copyright © 2020 Bullfinch Software. All rights reserved.
+//
+
+#import "BlueshiftLog.h"
+#import "BlueShift.h"
+#import "BlueShiftTrackEvents.h"
+
+@implementation BlueshiftLog
+
++ (void)logError:(NSError*) error withDescription:(NSString*)description methodName:(NSString*)method {
+    NSString* log = @"[Blueshift] Error : ";
+    @try {
+        if (description) {
+            log = [NSString stringWithFormat:@"%@%@",log,description];
+        }
+        if (method) {
+            log = [NSString stringWithFormat:@"%@\nMethod name: %@",log,method];
+        }
+        if (error) {
+            log = [NSString stringWithFormat:@"%@\n%@",log,error];
+        }
+        NSLog(@"%@", log);
+    } @catch (NSException *exception) {
+        NSLog(@"Failed to log error %@",exception);
+    }
+}
+
++ (void)logException:(NSException*) exception withDescription:(NSString*)description  methodName:(NSString*)method {
+    NSString* log = @"[Blueshift] Exception : ";
+    @try {
+        if (description) {
+            log = [NSString stringWithFormat:@"%@%@",log,description];
+        }
+        if (method) {
+            log = [NSString stringWithFormat:@"%@\nMethod name: %@",log,method];
+        }
+        if (exception) {
+            log = [NSString stringWithFormat:@"%@\n%@",log,exception];
+        }
+        NSLog(@"%@", log);
+    } @catch (NSException *exception) {
+        NSLog(@"Failed to log exception %@",exception);
+    }
+}
+
++ (void)logInfo:(NSString*)info withDetails: (id) details methodName:(NSString*)method{
+    if ([[BlueShift sharedInstance] config].debug) {
+        NSString* log = @"[Blueshift] info : ";
+        @try {
+            if (info) {
+                log = [NSString stringWithFormat:@"%@%@",log,info];
+            }
+            if (method) {
+                log = [NSString stringWithFormat:@"%@\nMethod name: %@ ",log,method];
+            }
+            if (details) {
+                log = [NSString stringWithFormat:@"%@\n%@",log,details];
+            }
+            NSLog(@"%@", log);
+        } @catch (NSException *exception) {
+            NSLog(@"Failed to log info %@",exception);
+        }
+    }
+}
+
++(void)logAPICallInfo:(NSString*)info withDetails: (NSDictionary*) details statusCode:(NSInteger)statusCode {
+    if ([[BlueShift sharedInstance] config].debug) {
+        NSString* log = @"[Blueshift] API call info : ";
+        @try {
+        if (info) {
+            log = [NSString stringWithFormat:@"%@%@",log,info];
+        }
+        if (statusCode!=0) {
+            log = [NSString stringWithFormat:@"%@\nStatus code:%ld",log,(long)statusCode];
+        }
+        if (details) {
+            if([details objectForKey:@"a"]) {
+                log = [NSString stringWithFormat:@"%@\nEVENT-%@ ",log, [details objectForKey:@"a"]];
+            } else if([details objectForKey:kEventGeneric]) {
+                log = [NSString stringWithFormat:@"%@\nEVENT-%@ ",log, [details objectForKey:kEventGeneric]];
+            }
+            log = [NSString stringWithFormat:@"%@\n%@",log,details];
+        }
+        NSLog(@"%@", log);
+        } @catch (NSException *exception) {
+            NSLog(@"Failed to log API call info %@",exception);
+        }
+    }
+
+}
+@end

--- a/BlueShift-iOS-SDK/HttpRequestOperationEntity.m
+++ b/BlueShift-iOS-SDK/HttpRequestOperationEntity.m
@@ -6,6 +6,7 @@
 //
 
 #import "HttpRequestOperationEntity.h"
+#import "BlueshiftLog.h"
 
 @implementation HttpRequestOperationEntity
 
@@ -26,7 +27,7 @@
             masterContext = appDelegate.managedObjectContext;
         }
         @catch (NSException *exception) {
-            NSLog(@"Caught exception %@", exception);
+            [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
         }
     }
     if (masterContext) {
@@ -64,7 +65,7 @@
             }
         }
         @catch (NSException *exception) {
-            NSLog(@"Caught exception %@", exception);
+            [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
         }
     } else {
         return ;
@@ -93,7 +94,7 @@
                     [fetchRequest setEntity:[NSEntityDescription entityForName:@"HttpRequestOperationEntity" inManagedObjectContext:context]];
                 }
                 @catch (NSException *exception) {
-                    NSLog(@"Caught exception %@", exception);
+                    [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
                 }
                 if(fetchRequest.entity != nil) {
                     NSNumber *currentTimeStamp = [NSNumber numberWithDouble:[[NSDate date] timeIntervalSinceReferenceDate] ];
@@ -118,7 +119,7 @@
                         }
                     }
                     @catch (NSException *exception) {
-                        NSLog(@"Caught exception %@", exception);
+                        [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
                     }
                 }
             }
@@ -141,7 +142,7 @@
                     [fetchRequest setEntity:[NSEntityDescription entityForName:@"HttpRequestOperationEntity" inManagedObjectContext:context]];
                 }
                 @catch (NSException *exception) {
-                    NSLog(@"Caught exception %@", exception);
+                    [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
                 }
                 if(fetchRequest.entity != nil) {
                     NSNumber *currentTimeStamp = [NSNumber numberWithDouble:[[[NSDate date] dateByAddingMinutes:kRequestRetryMinutesInterval] timeIntervalSince1970]];
@@ -162,7 +163,7 @@
                         }
                     }
                     @catch (NSException *exception) {
-                        NSLog(@"Caught exception %@", exception);
+                        [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
                     }
                 } else {
                     handler(NO, nil);

--- a/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationManager.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationManager.m
@@ -411,6 +411,7 @@
                 NSArray* filteredResults = [self filterInAppNotificationResults: sortedArray];
                 if ([filteredResults count] > 0) {
                     InAppNotificationEntity *entity = [filteredResults objectAtIndex:0];
+                    [BlueshiftLog logInfo:@"Fetched one in-app message from DB to display message id - " withDetails:entity.id methodName:nil];
                     [self createNotificationFromDictionary: entity];
                 }
             }
@@ -467,7 +468,9 @@
         NSString *notificationID = [self getInAppMessageID: notificationPayload];
         if (notificationID !=nil && ![notificationID isEqualToString:@""]) {
         [InAppNotificationEntity updateInAppNotificationStatus: masterContext forNotificatioID: notificationID request: fetchRequest notificationStatus:@"Displayed" andAppDelegate: appDelegate handler:^(BOOL status){
-            [BlueshiftLog logInfo:@"Marked in-app message in DB as Displayed, messageId : " withDetails:notificationID methodName:nil];
+            if (status) {   
+                [BlueshiftLog logInfo:@"Marked in-app message in DB as Displayed, messageId : " withDetails:notificationID methodName:nil];
+            }
         }];
         }
     }

--- a/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationManager.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationManager.m
@@ -15,6 +15,7 @@
 #import "BlueShiftInAppTriggerMode.h"
 #import "BlueShiftInAppNotificationConstant.h"
 #import "BlueShift.h"
+#import "../BlueshiftLog.h"
 
 #define THRESHOLD_FOR_UPCOMING_IAM  (30*60)         // 30 min set for time-being.
 
@@ -105,7 +106,7 @@
             masterContext = appDelegate.managedObjectContext;
         }
         @catch (NSException *exception) {
-            NSLog(@"Caught exception %@", exception);
+            [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
         }
     }
     
@@ -117,7 +118,7 @@
             [fetchRequest setEntity:entity];
         }
         @catch (NSException *exception) {
-            NSLog(@"Caught exception %@", exception);
+            [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
         }
         
         if(entity != nil && fetchRequest.entity != nil) {
@@ -177,7 +178,7 @@
                     masterContext = appDelegate.managedObjectContext;
                 }
                 @catch (NSException *exception) {
-                    NSLog(@"Caught exception %@", exception);
+                    [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
                 }
             }
             if(masterContext) {
@@ -188,7 +189,7 @@
                     [fetchRequest setEntity:entity];
                 }
                 @catch (NSException *exception) {
-                    NSLog(@"Caught exception %@", exception);
+                    [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
                 }
                 if(entity != nil && fetchRequest.entity != nil) {
                     InAppNotificationEntity *inAppNotificationEntity = [[InAppNotificationEntity alloc] initWithEntity:entity insertIntoManagedObjectContext: masterContext];
@@ -214,7 +215,7 @@
             masterContext = appDelegate.managedObjectContext;
         }
         @catch (NSException *exception) {
-            NSLog(@"Caught exception %@", exception);
+            [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
         }
     }
     
@@ -229,7 +230,7 @@
             count = [masterContext countForFetchRequest: fetchRequest error:&error];
         }
         @catch (NSException *exception) {
-            NSLog(@"Caught exception %@", exception);
+            [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
         }
         
         if(entity != nil && fetchRequest.entity != nil) {
@@ -240,6 +241,7 @@
                         double timeDifferenceInDay = [self checkInAppNotificationExpired: [notification.createdAt doubleValue]];
                         if (timeDifferenceInDay > 30 || count > 40) {
                             [self deleteNotification: notification context: masterContext];
+                            [BlueshiftLog logInfo:@"Deleted Expired notification, messageId : " withDetails:notification.id methodName:nil];
                         }
                     }
                 }
@@ -263,7 +265,7 @@
                 [context deleteObject: pManagedObject];
             }
             @catch (NSException *exception) {
-                NSLog(@"Caught exception %@", exception);
+                [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
             }
             [context performBlock:^{
                 NSError *saveError = nil;
@@ -290,7 +292,7 @@
             masterContext = appDelegate.managedObjectContext;
         }
         @catch (NSException *exception) {
-            NSLog(@"Caught exception %@", exception);
+            [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
         }
     }
     
@@ -303,7 +305,7 @@
             [fetchRequest setEntity:entity];
         }
         @catch (NSException *exception) {
-            NSLog(@"Caught exception %@", exception);
+            [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
         }
         
         if(entity != nil && fetchRequest.entity != nil) {
@@ -344,7 +346,7 @@
             masterContext = appDelegate.managedObjectContext;
         }
         @catch (NSException *exception) {
-            NSLog(@"Caught exception %@", exception);
+            [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
         }
     }
     
@@ -366,7 +368,7 @@
                         [context deleteObject: pManagedObject];
                     }
                     @catch (NSException *exception) {
-                        NSLog(@"Caught exception %@", exception);
+                        [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
                     }
                     [context performBlock:^{
                         NSError *saveError = nil;
@@ -385,7 +387,7 @@
             }
         }
         @catch (NSException *exception) {
-            NSLog(@"Caught exception %@", exception);
+            [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
         }
     }
 }
@@ -400,7 +402,7 @@
                 masterContext = appDelegate.managedObjectContext;
             }
             @catch (NSException *exception) {
-                NSLog(@"Caught exception %@", exception);
+                [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
             }
         }
         [InAppNotificationEntity fetchAll:triggerMode forDisplayPage: [self inAppNotificationDisplayOnPage] context:masterContext withHandler:^(BOOL status, NSArray *results) {
@@ -448,7 +450,7 @@
             masterContext = appDelegate.managedObjectContext;
         }
         @catch (NSException *exception) {
-            NSLog(@"Caught exception %@", exception);
+            [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
         }
     }
     if(masterContext) {
@@ -459,12 +461,14 @@
             [fetchRequest setEntity:entity];
         }
         @catch (NSException *exception) {
-            NSLog(@"Caught exception %@", exception);
+            [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
         }
         
         NSString *notificationID = [self getInAppMessageID: notificationPayload];
         if (notificationID !=nil && ![notificationID isEqualToString:@""]) {
-        [InAppNotificationEntity updateInAppNotificationStatus: masterContext forNotificatioID: notificationID request: fetchRequest notificationStatus:@"Displayed" andAppDelegate: appDelegate handler:^(BOOL status){ }];
+        [InAppNotificationEntity updateInAppNotificationStatus: masterContext forNotificatioID: notificationID request: fetchRequest notificationStatus:@"Displayed" andAppDelegate: appDelegate handler:^(BOOL status){
+            [BlueshiftLog logInfo:@"Marked in-app message in DB as Displayed, messageId : " withDetails:notificationID methodName:nil];
+        }];
         }
     }
 }
@@ -486,6 +490,7 @@
             if (currentTime - THRESHOLD_FOR_UPCOMING_IAM > endTime) {
                 /* discard notification if its expired. */
                 [self removeInAppNotificationFromDB: entity.objectID];
+                [BlueshiftLog logInfo:@"Deleted Expired notification, messageId : " withDetails:entity.id methodName:nil];
             } else {
                 /* For 'Now' category msg show it if time is not expired */
                 [nowFilteredResults addObject:entity];
@@ -497,6 +502,7 @@
             if ((currentTime - THRESHOLD_FOR_UPCOMING_IAM) > endTime) {
                 /* discard notification if its expired. */
                 [self removeInAppNotificationFromDB: entity.objectID];
+                [BlueshiftLog logInfo:@"Deleted Expired notification, messageId : " withDetails:entity.id methodName:nil];
             } else if (startTime > currentTime) {
                 /* Wait for (startTime-currentTime) before IAM is shown */
                 continue;
@@ -516,6 +522,7 @@
                                                                   selector:@selector(fetchNowAndUpcomingInAppMessageFromDB)
                                                                   userInfo:nil
                                                                    repeats: NO];
+        [BlueshiftLog logInfo:@"Started InAppMessageFetchTimer" withDetails:nil methodName:nil];
     }
 }
 
@@ -524,6 +531,7 @@
     if (self.inAppMessageFetchTimer != nil) {
         [self.inAppMessageFetchTimer invalidate];
         self.inAppMessageFetchTimer = nil;
+        [BlueshiftLog logInfo:@"Stopped InAppMessageFetchTimer" withDetails:nil methodName:nil];
     }
 }
 
@@ -573,6 +581,7 @@
         [self presentInAppNotification:notificationController];
     }
     if (errorString) {
+        [BlueshiftLog logError:nil withDescription:errorString methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
     }
 }
 
@@ -584,6 +593,7 @@
 
 - (void)createNotificationFromDictionary:(InAppNotificationEntity *) inAppEntity {
     BlueShiftInAppNotification *inAppNotification = [[BlueShiftInAppNotification alloc] initFromEntity:inAppEntity];
+    [BlueshiftLog logInfo:@"Created in-app message to display, message Id: " withDetails:inAppEntity.id methodName:nil];
     [self createNotification: inAppNotification];
 }
 

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationModalViewController.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationModalViewController.m
@@ -113,7 +113,6 @@
             NSString *fileName = [BlueShiftInAppNotificationHelper createFileNameFromURL: self.notification.notificationContent.banner];
             if (fileName && [BlueShiftInAppNotificationHelper hasFileExist: fileName]) {
                 [BlueShiftInAppNotificationHelper deleteFileFromLocal: fileName];
-                NSLog(@"Image file deleted");
             }
         }
     };

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationViewController.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationViewController.m
@@ -11,6 +11,7 @@
 #import <CoreText/CoreText.h>
 #import "BlueShiftInAppNotificationConstant.h"
 #import "BlueShiftNotificationCloseButton.h"
+#import "../BlueshiftLog.h"
 
 @interface BlueShiftNotificationViewController () {
     BlueShiftNotificationCloseButton *_closeButton;
@@ -350,7 +351,7 @@
         BOOL failedToRegisterFont = NO;
         if (!CTFontManagerRegisterGraphicsFont(font, &error)) {
             CFStringRef errorDescription = CFErrorCopyDescription(error);
-            NSLog(@"Error: Cannot load Font Awesome");
+            [BlueshiftLog logError:nil withDescription:@"Failed to load FontAwesome" methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
             CFBridgingRelease(errorDescription);
             failedToRegisterFont = YES;
         }

--- a/BlueShift-iOS-SDK/InApps/BlueshiftInAppNotificationRequest.m
+++ b/BlueShift-iOS-SDK/InApps/BlueshiftInAppNotificationRequest.m
@@ -40,6 +40,7 @@
          }
         [[BlueShiftRequestOperationManager sharedRequestOperationManager] postRequestWithURL: url andParams: parameters completetionHandler:^(BOOL status, NSDictionary *data, NSError *error) {
             if (status) {
+                [BlueshiftLog logAPICallInfo:@"Succesfully fetched in-app messages." withDetails:data statusCode:0];
                 success(data);
             } else {
                 failure(error);

--- a/BlueShift-iOS-SDK/InApps/BlueshiftInAppNotificationRequest.m
+++ b/BlueShift-iOS-SDK/InApps/BlueshiftInAppNotificationRequest.m
@@ -6,6 +6,7 @@
 //
 
 #import "BlueshiftInAppNotificationRequest.h"
+#import "../BlueshiftLog.h"
 
 @implementation BlueshiftInAppNotificationRequest
 
@@ -45,8 +46,8 @@
             }
         }];
     } else {
-        NSLog(@"Device ID is not there");
-        NSError *error = (NSError*)@"Device ID not set";
+        NSError *error = (NSError*)@"Device ID is missing";
+        [BlueshiftLog logError:error withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
         failure(error);
     }
 }

--- a/BlueShift-iOS-SDK/InApps/InAppNotificationEntity.m
+++ b/BlueShift-iOS-SDK/InApps/InAppNotificationEntity.m
@@ -10,6 +10,7 @@
 #import "BlueShiftInAppNotification.h"
 #import "BlueShiftAppDelegate.h"
 #import "../BlueShiftNotificationConstants.h"
+#import "../BlueshiftLog.h"
 
 @implementation InAppNotificationEntity
 
@@ -38,7 +39,7 @@
             [fetchRequest setEntity:[NSEntityDescription entityForName: kInAppNotificationEntityNameKey inManagedObjectContext: masterContext]];
         }
         @catch (NSException *exception) {
-            NSLog(@"Caught exception %@", exception);
+            [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
         }
         if(fetchRequest.entity != nil) {
             [self fetchFromCoreDataFromContext: masterContext forTriggerMode: triggerMode forDisplayPage: displayOn request: fetchRequest handler: handler];
@@ -94,7 +95,7 @@
         }
     }
     @catch (NSException *exception) {
-        NSLog(@"Caught exception %@", exception);
+        [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
     }
 }
 
@@ -143,7 +144,7 @@
             }
         }
         @catch (NSException *exception) {
-            NSLog(@"Caught exception %@", exception);
+            [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
             handler(NO);
         }
     } else {
@@ -173,7 +174,7 @@
         }
     }
     @catch (NSException *exception) {
-        NSLog(@"Caught exception %@", exception);
+        [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
     }
 }
 
@@ -200,7 +201,7 @@
         }
     }
     @catch (NSException *exception) {
-        NSLog(@"Caught exception %@", exception);
+        [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
     }
 }
 
@@ -227,7 +228,7 @@
                 }
             }
             @catch (NSException *exception) {
-                NSLog(@"Caught exception %@", exception);
+                [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
                 handler(NO);
             }
         } else {


### PR DESCRIPTION
Introducing new Blueshift logger, which has 4 categories as below.
- Error
- Exception
- info
- Api call info

By default error and exception logs are enabled, to enable info and api call info logs, debug flag from SDK config needs to be set true.