### PR TITLE
deviceToken hot fix

### DIFF
--- a/BlueShift-iOS-SDK/BlueShiftDeviceData.m
+++ b/BlueShift-iOS-SDK/BlueShiftDeviceData.m
@@ -93,8 +93,8 @@ static BlueShiftDeviceData *_currentDeviceData = nil;
         [deviceMutableDictionary setObject:self.deviceType forKey:@"device_type"];
     }
     
-    if (self.deviceToken) {
-        NSString *storedDeviceToken = [[BlueShift sharedInstance] getDeviceToken];
+    NSString *storedDeviceToken = [[BlueShift sharedInstance] getDeviceToken];
+    if (storedDeviceToken) {
         [deviceMutableDictionary setObject:storedDeviceToken forKey:@"device_token"];
     }
     


### PR DESCRIPTION
fix: The app is crashing in some cases when device token is nil