### PR TITLE
fix: carousel clk_url tracking was not sending deep_link url

### DIFF
--- a/BlueShift-iOS-SDK/BlueShiftRequestOperationManager.m
+++ b/BlueShift-iOS-SDK/BlueShiftRequestOperationManager.m
@@ -93,7 +93,7 @@ static BlueShiftRequestOperationManager *_sharedRequestOperationManager = nil;
                 handler(false, nil, error);
             }
         } else {
-            [BlueshiftLog logAPICallInfo:[NSString stringWithFormat:@"GET - Fail %@",url] withDetails:nil statusCode:statusCode];
+            [BlueshiftLog logAPICallInfo:[NSString stringWithFormat:@"GET - Fail %@",url] withDetails:@{@"error":error} statusCode:statusCode];
             handler(false, nil, error);
         }
         
@@ -131,7 +131,7 @@ static BlueShiftRequestOperationManager *_sharedRequestOperationManager = nil;
                 handler(false, nil, error);
             }
         } else {
-            [BlueshiftLog logAPICallInfo:[NSString stringWithFormat:@"POST - Fail %@",url] withDetails:nil statusCode:statusCode];
+            [BlueshiftLog logAPICallInfo:[NSString stringWithFormat:@"POST - Fail %@",url] withDetails:@{@"error":error} statusCode:statusCode];
             handler(false, nil, error);
         }
         
@@ -160,7 +160,7 @@ static BlueShiftRequestOperationManager *_sharedRequestOperationManager = nil;
                 handler(NO,nil,[NSError errorWithDomain:@"Failed to load redirection link" code:httpResponse.statusCode userInfo:nil]);
             }
         } else {
-            [BlueshiftLog logAPICallInfo:[NSString stringWithFormat:@"ULReplay - Fail %@",[[httpResponse URL] absoluteString]] withDetails:nil statusCode:httpResponse.statusCode];
+            [BlueshiftLog logAPICallInfo:[NSString stringWithFormat:@"ULReplay - Fail %@",[[httpResponse URL] absoluteString]] withDetails:@{@"error":error} statusCode:httpResponse.statusCode];
             handler(NO,nil,error);
         }
     }];

--- a/BlueShift-iOS-SDK/BlueshiftEventAnalyticsHelper.m
+++ b/BlueShift-iOS-SDK/BlueshiftEventAnalyticsHelper.m
@@ -48,7 +48,7 @@
     if ([self isNotNilAndNotEmpty:urlElement]) {
         [pushTrackParametersMutableDictionary setObject:urlElement forKey: kNotificationURLElementKey];
     }
-    if([[pushDetailsDictionary objectForKey: kNotificationTypeIdentifierKey] isEqualToString:kNotificationKey] && pushDeepLinkURL) {
+    if([[pushDetailsDictionary objectForKey: kNotificationTypeIdentifierKey] isEqualToString:kNotificationKey] && [self isNotNilAndNotEmpty:pushDeepLinkURL]) {
         NSString *encodedUrl = [BlueShiftInAppNotificationHelper getEncodedURLString:pushDeepLinkURL];
         [pushTrackParametersMutableDictionary setObject:encodedUrl forKey: kNotificationURLElementKey];
     }


### PR DESCRIPTION
- MOBL-416 Carousel click tracking call was not sending deep_link url
- Removed duplicate trackAppOpen call as it is getting called from the setupPushNotificationDeeplink as well.
- MOBL-417 logged error details for the API calls
- added check for not empty for pushDeepLinkURL