### PR TITLE
Feature/register for silent push

### DIFF
--- a/BlueShift-iOS-SDK/BlueShift.m
+++ b/BlueShift-iOS-SDK/BlueShift.m
@@ -114,8 +114,9 @@ static BlueShift *_sharedBlueShiftInstance = nil;
     if (config.enablePushNotification == YES) {
         [blueShiftAppDelegate registerForNotification];
         [blueShiftAppDelegate handleRemoteNotificationOnLaunchWithLaunchOptions:config.applicationLaunchOptions];
+    } else {
+        [blueShiftAppDelegate registerForSilentPushNotification];
     }
-
     // Initialize In App Manager
     _inAppNotificationMananger = [[BlueShiftInAppNotificationManager alloc] init];
     if (config.inAppNotificationDelegate) {
@@ -135,8 +136,10 @@ static BlueShift *_sharedBlueShiftInstance = nil;
             [self fetchInAppNotificationFromDB];
         } failure:^(NSError *error){ }];
     }
-    //Mark app open
-    [blueShiftAppDelegate trackAppOpenWithParameters:nil];
+    //Mark app open if device token is already present, else delay it till app receves device token
+    if ([self getDeviceToken]) {
+        [blueShiftAppDelegate trackAppOpenWithParameters:nil];
+    }
     
     [[BlueShiftDeviceData currentDeviceData] saveDeviceDataForNotificationExtensionUse];
 
@@ -174,13 +177,13 @@ static BlueShift *_sharedBlueShiftInstance = nil;
 
 - (void)setDeviceToken {
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    [defaults setObject:[BlueShiftDeviceData currentDeviceData].deviceToken forKey:@"deviceToken"];
+    [defaults setObject:[BlueShiftDeviceData currentDeviceData].deviceToken forKey:@"BlueshiftDeviceToken"];
     [defaults synchronize];
 }
 
 - (NSString *) getDeviceToken {
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    _deviceToken = (NSString *)[defaults objectForKey:@"deviceToken"];
+    _deviceToken = (NSString *)[defaults objectForKey:@"BlueshiftDeviceToken"];
     return _deviceToken;
 }
 

--- a/BlueShift-iOS-SDK/BlueShiftAppData.h
+++ b/BlueShift-iOS-SDK/BlueShiftAppData.h
@@ -14,6 +14,7 @@
 @property (nonatomic, strong) NSString *appVersion;
 @property (nonatomic, strong) NSString *appBuildNumber;
 @property (nonatomic, strong) NSString *bundleIdentifier;
+@property (nonatomic, strong) NSString *isPushPermissionAccepted;
 
 + (instancetype) currentAppData;
 

--- a/BlueShift-iOS-SDK/BlueShiftAppData.h
+++ b/BlueShift-iOS-SDK/BlueShiftAppData.h
@@ -14,7 +14,7 @@
 @property (nonatomic, strong) NSString *appVersion;
 @property (nonatomic, strong) NSString *appBuildNumber;
 @property (nonatomic, strong) NSString *bundleIdentifier;
-@property (nonatomic, strong) NSString *isPushPermissionAccepted;
+@property BOOL isPushPermissionAccepted;
 
 + (instancetype) currentAppData;
 

--- a/BlueShift-iOS-SDK/BlueShiftAppData.m
+++ b/BlueShift-iOS-SDK/BlueShiftAppData.m
@@ -8,6 +8,7 @@
 
 #import "BlueShiftAppData.h"
 #import "BlueShift.h"
+#import "BlueshiftLog.h"
 
 #define kEnablePush                             @"enable_push"
 #define kEnableInApp                            @"enable_inapp"
@@ -16,7 +17,6 @@
 #define kAppVersion                             @"app_version"
 #define kAppName                                @"app_name"
 #define kCFBundleShortVersionString             @"CFBundleShortVersionString"
-#define kBlueshiftIsPushPermissionAccepted      @"BlueshiftIsPushPermissionAccepted"
 
 static BlueShiftAppData *_currentAppData = nil;
 
@@ -46,18 +46,6 @@ static BlueShiftAppData *_currentAppData = nil;
     return [[[NSBundle mainBundle] infoDictionary] objectForKey:(NSString *)kCFBundleIdentifierKey];
 }
 
-- (NSString*)isPushPermissionAccepted {
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    NSString* isPushAccepted = (NSString *)[defaults objectForKey:kBlueshiftIsPushPermissionAccepted];
-    return  isPushAccepted;
-}
-
-- (void)setIsPushPermissionAccepted:(NSString*)isPushPermissionAccepted {
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    [defaults setObject:isPushPermissionAccepted forKey:kBlueshiftIsPushPermissionAccepted];
-    [[BlueShift sharedInstance] identifyUserWithDetails:nil canBatchThisEvent:NO];
-}
-
 - (NSDictionary *)toDictionary {
     NSMutableDictionary *appMutableDictionary = [NSMutableDictionary dictionary];
     if (self.appName) {
@@ -77,9 +65,8 @@ static BlueShiftAppData *_currentAppData = nil;
     }
     
     if (@available(iOS 10.0, *)) {
-        BOOL isPushEnabledBool = [[self isPushPermissionAccepted] isEqualToString:@"YES"] ? YES : NO;
-        NSNumber *isPushEnabledNumber = [NSNumber numberWithBool: isPushEnabledBool];
-        [appMutableDictionary setObject: isPushEnabledNumber  forKey:kEnablePush];
+        NSNumber *isPushEnabled = [NSNumber numberWithBool: self.isPushPermissionAccepted];
+        [appMutableDictionary setObject: isPushEnabled  forKey:kEnablePush];
     }
     
     NSNumber *enableInApp = [NSNumber numberWithBool: [[[BlueShift sharedInstance] config] enableInAppNotification]];

--- a/BlueShift-iOS-SDK/BlueShiftAppDelegate.h
+++ b/BlueShift-iOS-SDK/BlueShiftAppDelegate.h
@@ -64,6 +64,7 @@
 - (void)handleBlueshiftUniversalLinksForActivity:(NSUserActivity *_Nonnull)activity API_AVAILABLE(ios(8.0));
 - (void)handleBlueshiftUniversalLinksForURL:(NSURL *_Nonnull)url  API_AVAILABLE(ios(8.0));
 - (void)trackAppOpenWithParameters:(NSDictionary *_Nullable)parameters;
+- (void)registerForSilentPushNotification;
 
 @end
 #endif

--- a/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
+++ b/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
@@ -29,29 +29,64 @@
 
 #pragma mark - Remote notification registration
 - (void) registerForNotification {
-    if ([[UIApplication sharedApplication] respondsToSelector:@selector(registerUserNotificationSettings:)]) {
-        if(SYSTEM_VERSION_GRATERTHAN_OR_EQUALTO(@"10.0")){
-            if (@available(iOS 10.0, *)) {
-                UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-                center.delegate = self.userNotificationDelegate;
-                [center setNotificationCategories: [[[BlueShift sharedInstance] userNotification] notificationCategories]];
-                [center requestAuthorizationWithOptions:([[[BlueShift sharedInstance] userNotification] notificationTypes]) completionHandler:^(BOOL granted, NSError * _Nullable error){
-                    if(!error){
-                        dispatch_async(dispatch_get_main_queue(), ^(void) {
-                            [[UIApplication sharedApplication] registerForRemoteNotifications];
-                        });
-                    }
-                }];
+    if (@available(iOS 10.0, *)) {
+        UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+        center.delegate = self.userNotificationDelegate;
+        [center setNotificationCategories: [[[BlueShift sharedInstance] userNotification] notificationCategories]];
+        [center requestAuthorizationWithOptions:([[[BlueShift sharedInstance] userNotification] notificationTypes]) completionHandler:^(BOOL granted, NSError * _Nullable error){
+            if(!error){
+                dispatch_async(dispatch_get_main_queue(), ^(void) {
+                    [[UIApplication sharedApplication] registerForRemoteNotifications];
+                });
             }
-        } else {
-           if (@available(iOS 10.0, *)) {
-                UIUserNotificationSettings* notificationSettings = [[[BlueShift sharedInstance] pushNotification] notificationSettings];
-                [[UIApplication sharedApplication] registerUserNotificationSettings: notificationSettings];
-                [[UIApplication sharedApplication] registerForRemoteNotifications];
+            [self setPushEnabled];
+            if (granted) {
+                [BlueshiftLog logInfo:@"Push notification permission is granted. Registered successfully for push notifications" withDetails:nil methodName:nil];
+            } else {
+                [BlueshiftLog logInfo:@"Push notification permission is denied. Registered successfully for background silent notifications" withDetails:nil methodName:nil];
             }
-        }
-        
-        [self downloadFileFromURL];
+        }];
+    } else if ([UIApplication respondsToSelector:@selector(registerUserNotificationSettings:)]) {
+        [[UIApplication sharedApplication] registerUserNotificationSettings:[UIUserNotificationSettings settingsForTypes:([[[BlueShift sharedInstance] pushNotification] notificationTypes]) categories:[[[BlueShift sharedInstance] pushNotification] notificationCategories]]];
+            [[UIApplication sharedApplication] registerForRemoteNotifications];
+    }
+    [self downloadFileFromURL];
+}
+
+- (void)registerForSilentPushNotification {
+    if (@available(iOS 10.0, *)) {
+        [[UNUserNotificationCenter currentNotificationCenter] getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings * _Nonnull settings) {
+            if ([settings authorizationStatus] != UNAuthorizationStatusAuthorized) {
+                dispatch_async(dispatch_get_main_queue(), ^(void) {
+                    [[UIApplication sharedApplication] registerForRemoteNotifications];
+                });
+                [self setPushEnabled];
+                [BlueshiftLog logInfo:@"config.enablePushNotification is set to false. Registered successfully for background silent notifications" withDetails:nil methodName:nil];
+            } else {
+                [self registerForNotification];
+            }
+        }];
+    }
+    [self downloadFileFromURL];
+}
+
+- (void)setPushEnabled {
+    if (@available(iOS 10.0, *)) {
+        [[UNUserNotificationCenter currentNotificationCenter] getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings * _Nonnull settings) {
+            NSString* isPermissionAccepted = [[BlueShiftAppData currentAppData] isPushPermissionAccepted];
+            if ([settings authorizationStatus] == UNAuthorizationStatusAuthorized) {
+                if(!isPermissionAccepted || [isPermissionAccepted isEqualToString:@"NO"]) {
+                    [[BlueShiftAppData currentAppData] setIsPushPermissionAccepted:@"YES"];
+                    [BlueshiftLog logInfo:@"enable_push status changed from NO to YES" withDetails:nil methodName:nil];
+                    [self registerForNotification];
+                }
+            } else {
+                if(!isPermissionAccepted || [isPermissionAccepted isEqualToString:@"YES"]) {
+                    [[BlueShiftAppData currentAppData] setIsPushPermissionAccepted:@"NO"];
+                    [BlueshiftLog logInfo:@"enable_push status changed from YES to NO" withDetails:nil methodName:nil];
+                }
+            }
+        }];
     }
 }
 
@@ -69,23 +104,6 @@
 }
 
 - (void) registerForRemoteNotification:(NSData *)deviceToken {
-    if (@available(iOS 8.0, *)) {
-        if ([[[UIApplication sharedApplication] currentUserNotificationSettings] types]) {
-            NSDictionary *userInfo =
-            [NSDictionary dictionaryWithObject:@YES forKey:[[[BlueShift sharedInstance] config] isEnabledPushNotificationKey]];
-            [[NSNotificationCenter defaultCenter] postNotificationName:
-             [[[BlueShift sharedInstance] config] blueShiftNotificationName] object:nil userInfo:userInfo];
-        }
-        else {
-            NSDictionary *userInfo =
-            [NSDictionary dictionaryWithObject:@NO forKey:[[[BlueShift sharedInstance] config] isEnabledPushNotificationKey]];
-            [[NSNotificationCenter defaultCenter] postNotificationName:
-             [[[BlueShift sharedInstance] config] blueShiftNotificationName] object:nil userInfo:userInfo];
-        }
-    } else {
-        // Fallback on earlier versions
-    }
-
     NSString *deviceTokenString = [self hexadecimalStringFromData: deviceToken];
     deviceTokenString = [deviceTokenString stringByReplacingOccurrencesOfString:@" " withString:@""];
     [BlueShiftDeviceData currentDeviceData].deviceToken = deviceTokenString;
@@ -115,6 +133,11 @@
 }
 
 - (void)fireIdentifyCall {
+    //fire delayed app_open on receiving device_token for very first time
+    if(![[BlueShift sharedInstance] getDeviceToken]) {
+        [self trackAppOpenWithParameters:nil];
+    }
+
     [[BlueShift sharedInstance] setDeviceToken];
     NSString *email = [BlueShiftUserInfo sharedInstance].email;
     if (email && ![email isEqualToString:@""]) {
@@ -131,10 +154,6 @@
 
 - (void) failedToRegisterForRemoteNotificationWithError:(NSError *)error {
     [BlueshiftLog logError:error withDescription:[NSString stringWithFormat:@"Failed to register for remote notification"] methodName:nil];
-    NSDictionary *userInfo =
-    [NSDictionary dictionaryWithObject:@NO forKey:[[[BlueShift sharedInstance] config] isEnabledPushNotificationKey]];
-    [[NSNotificationCenter defaultCenter] postNotificationName:
-     [[[BlueShift sharedInstance] config] blueShiftNotificationName] object:nil userInfo:userInfo];
 }
 
 - (void)application:(UIApplication*)application didFailToRegisterForRemoteNotificationsWithError:(NSError*)error {
@@ -839,7 +858,7 @@
     if ([BlueShift sharedInstance].config.enableAnalytics) {
         [BlueShiftHttpRequestBatchUpload batchEventsUploadInBackground];
     }
-    // Will have to handled by SDK .....
+    [self setPushEnabled];
 }
 
 - (void)applicationDidBecomeActive:(UIApplication *)application {

--- a/BlueShift-iOS-SDK/BlueShiftConfig.h
+++ b/BlueShift-iOS-SDK/BlueShiftConfig.h
@@ -46,8 +46,6 @@
 @property id<BlueShiftInAppNotificationDelegate> _Nonnull inAppNotificationDelegate;
 @property id<BlueshiftUniversalLinksDelegate> _Nonnull blueshiftUniversalLinksDelegate;
 
-@property NSString * _Nonnull blueShiftNotificationName;
-@property NSString * _Nonnull isEnabledPushNotificationKey;
 @property(nonatomic) double BlueshiftInAppNotificationTimeInterval;
 @property (nonatomic, assign) BlueshiftDeviceIdSource blueshiftDeviceIdSource;
 

--- a/BlueShift-iOS-SDK/BlueShiftConfig.m
+++ b/BlueShift-iOS-SDK/BlueShiftConfig.m
@@ -18,8 +18,6 @@
         self.enableLocationAccess = YES;
         self.enableAnalytics = YES;
         self.enableAppOpenTrackEvent = YES;
-        self.blueShiftNotificationName = @"BlueShiftPushNotificationSetting";
-        self.isEnabledPushNotificationKey = @"isEnabled";
         
         self.debug = NO;
         

--- a/BlueShift-iOS-SDK/BlueShiftDeviceData.m
+++ b/BlueShift-iOS-SDK/BlueShiftDeviceData.m
@@ -144,7 +144,7 @@ static BlueShiftDeviceData *_currentDeviceData = nil;
         NSString *IDFAString = [self.deviceIDFA isEqualToString:kIDFADefaultValue] ? @"" : self.deviceIDFA;
         [deviceMutableDictionary setObject:IDFAString forKey:kDeviceIDFA];
     }
-        
+
     return [deviceMutableDictionary copy];
 }
 

--- a/BlueShift-iOS-SDK/BlueShiftDeviceData.m
+++ b/BlueShift-iOS-SDK/BlueShiftDeviceData.m
@@ -144,7 +144,7 @@ static BlueShiftDeviceData *_currentDeviceData = nil;
         NSString *IDFAString = [self.deviceIDFA isEqualToString:kIDFADefaultValue] ? @"" : self.deviceIDFA;
         [deviceMutableDictionary setObject:IDFAString forKey:kDeviceIDFA];
     }
-    
+        
     return [deviceMutableDictionary copy];
 }
 

--- a/BlueShift-iOS-SDK/BlueShiftUserInfo.m
+++ b/BlueShift-iOS-SDK/BlueShiftUserInfo.m
@@ -90,11 +90,6 @@ static BlueShiftUserInfo *_sharedUserInfo = nil;
         [sharedUserInfoMutableDictionary setObject:dateOfBirthTimeStamp forKey:@"date_of_birth"];
     }
     
-    
-    NSNumber *enableInApp = [NSNumber numberWithBool: [[[BlueShift sharedInstance] config] enableInAppNotification]];
-    [sharedUserInfoMutableDictionary setObject: enableInApp  forKey:@"enable_inapp"];
-
-    
     return [sharedUserInfoMutableDictionary copy];
 }
 


### PR DESCRIPTION
Added registration for silent push functionality for delayed push notification permission
added delay of 2 secs for app_open call for first time when device token is missing
removed redundant code of tracking call
changed device token userdefault key
Added autoIdentifyCheck to fire identify if push permission value changes
Added constant keys for BlueshiftAppData
Added notification registration call for iOS 9 and below OS version
Removed unused code from registerForRemoteNotification method and variables from Blueshift Config
Moved enable_inapp to BlueshiftAppData