### PR TITLE
added auto identify check on appBeacomeActive

### DIFF
--- a/BlueShift-iOS-SDK/BlueShiftAppData.m
+++ b/BlueShift-iOS-SDK/BlueShiftAppData.m
@@ -43,13 +43,13 @@ static BlueShiftAppData *_currentAppData = nil;
     NSString *val = [[NSUserDefaults standardUserDefaults] objectForKey:kBlueshiftEnablePush];
     BOOL enablePush = YES;
     if (val) {
-        enablePush = [val isEqual:@"YES"] ? YES : NO;
+        enablePush = [val isEqual:kYES] ? YES : NO;
     }
     return enablePush;
 }
 
 - (void)setEnablePush:(BOOL)enablePush {
-    NSString *val = enablePush ? @"YES" : @"NO";
+    NSString *val = enablePush ? kYES : kNO;
     [[NSUserDefaults standardUserDefaults] setObject:val forKey:kBlueshiftEnablePush];
 }
 

--- a/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
+++ b/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
@@ -155,15 +155,15 @@
 - (BOOL)validateChangeInUNAuthorizationStatus {
      NSString* lastModifiedUNAuthorizationStatus = [self getLastModifiedUNAuthorizationStatus];
     if ([[BlueShiftAppData currentAppData] currentUNAuthorizationStatus]) {
-        if(!lastModifiedUNAuthorizationStatus || [lastModifiedUNAuthorizationStatus isEqualToString:@"NO"]) {
-            [self setLastModifiedUNAuthorizationStatus: @"YES"];
+        if(!lastModifiedUNAuthorizationStatus || [lastModifiedUNAuthorizationStatus isEqualToString:kNO]) {
+            [self setLastModifiedUNAuthorizationStatus: kYES];
             [BlueshiftLog logInfo:@"UNAuthorizationStatus status changed to YES" withDetails:nil methodName:nil];
             [[[BlueShift sharedInstance]appDelegate] registerForNotification];
             return YES;
         }
     } else {
-        if(!lastModifiedUNAuthorizationStatus || [lastModifiedUNAuthorizationStatus isEqualToString:@"YES"]) {
-            [self setLastModifiedUNAuthorizationStatus: @"NO"];
+        if(!lastModifiedUNAuthorizationStatus || [lastModifiedUNAuthorizationStatus isEqualToString:kYES]) {
+            [self setLastModifiedUNAuthorizationStatus: kNO];
             [BlueshiftLog logInfo:@"UNAuthorizationStatus status changed to NO" withDetails:nil methodName:nil];
             return YES;
         }

--- a/BlueShift-iOS-SDK/BlueshiftConstants.h
+++ b/BlueShift-iOS-SDK/BlueshiftConstants.h
@@ -39,5 +39,8 @@
 #define kBlueshiftDeviceToken                   @"BlueshiftDeviceToken"
 #define kBlueshiftEnablePush                    @"BlueshiftEnablePush"
 
+//Bool
+#define kYES                                    @"YES"
+#define kNO                                     @"NO"
 
 #endif /* BlueshiftConstants_h */

--- a/BlueShift-iOS-SDK/HttpRequestOperationEntity.m
+++ b/BlueShift-iOS-SDK/HttpRequestOperationEntity.m
@@ -84,7 +84,8 @@
 // Method to return the first record from Core Data ...
 
 + (void *)fetchFirstRecordFromCoreDataWithCompletetionHandler:(void (^)(BOOL, HttpRequestOperationEntity *))handler {
-    @try {
+    NSString *key = [NSString stringWithUTF8String:__PRETTY_FUNCTION__];
+    @synchronized (key) {
         BlueShiftAppDelegate *appDelegate = (BlueShiftAppDelegate *)[BlueShift sharedInstance].appDelegate;
         if(appDelegate != nil && appDelegate.realEventManagedObjectContext != nil) {
             NSManagedObjectContext *context = appDelegate.realEventManagedObjectContext;
@@ -126,15 +127,14 @@
         } else {
             handler(NO, nil);
         }
-    } @catch (NSException *exception) {
-        [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
     }
 }
     
 
 // Method to return the batch records from Core Data ....
 + (void *)fetchBatchWiseRecordFromCoreDataWithCompletetionHandler:(void (^)(BOOL, NSArray *))handler {
-    @try {
+    NSString *key = [NSString stringWithUTF8String:__PRETTY_FUNCTION__];
+    @synchronized(key) {
         BlueShiftAppDelegate *appDelegate = (BlueShiftAppDelegate *)[BlueShift sharedInstance].appDelegate;
         if(appDelegate != nil && appDelegate.batchEventManagedObjectContext != nil) {
             NSManagedObjectContext *context = appDelegate.batchEventManagedObjectContext;
@@ -176,8 +176,6 @@
         } else {
             handler(NO, nil);
         }
-    } @catch (NSException *exception) {
-        [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
     }
 }
 

--- a/BlueShift-iOS-SDK/HttpRequestOperationEntity.m
+++ b/BlueShift-iOS-SDK/HttpRequestOperationEntity.m
@@ -84,7 +84,7 @@
 // Method to return the first record from Core Data ...
 
 + (void *)fetchFirstRecordFromCoreDataWithCompletetionHandler:(void (^)(BOOL, HttpRequestOperationEntity *))handler {
-    @synchronized(self) {
+    @try {
         BlueShiftAppDelegate *appDelegate = (BlueShiftAppDelegate *)[BlueShift sharedInstance].appDelegate;
         if(appDelegate != nil && appDelegate.realEventManagedObjectContext != nil) {
             NSManagedObjectContext *context = appDelegate.realEventManagedObjectContext;
@@ -126,13 +126,15 @@
         } else {
             handler(NO, nil);
         }
+    } @catch (NSException *exception) {
+        [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
     }
 }
     
 
 // Method to return the batch records from Core Data ....
 + (void *)fetchBatchWiseRecordFromCoreDataWithCompletetionHandler:(void (^)(BOOL, NSArray *))handler {
-    @synchronized(self) {
+    @try {
         BlueShiftAppDelegate *appDelegate = (BlueShiftAppDelegate *)[BlueShift sharedInstance].appDelegate;
         if(appDelegate != nil && appDelegate.batchEventManagedObjectContext != nil) {
             NSManagedObjectContext *context = appDelegate.batchEventManagedObjectContext;
@@ -174,6 +176,8 @@
         } else {
             handler(NO, nil);
         }
+    } @catch (NSException *exception) {
+        [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
     }
 }
 


### PR DESCRIPTION
Removed @synchronised(self) as It was blocking the execution of real-time event and batched event at same time.  Now the managedContexts are different for real-time and batched events which can take care of synchronous execution.
Moved code to BlueshiftAppDelegate