### PR TITLE
MOBL-486 - Add appDelegate window object check 

### DIFF
--- a/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
+++ b/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
@@ -12,6 +12,7 @@
 #import "BlueShiftInAppNotificationConstant.h"
 #import "BlueshiftLog.h"
 #import "BlueshiftConstants.h"
+#import "InApps/BlueShiftInAppNotificationHelper.h"
 
 #define SYSTEM_VERSION_GRATERTHAN_OR_EQUALTO(v) ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedAscending)
 
@@ -337,12 +338,19 @@
     [self trackPushViewedWithParameters:userInfo];
     self.userInfo = userInfo;
     // Handle push notification when the app is in active state...
-    UIViewController *topViewController = [self topViewController:[[UIApplication sharedApplication].keyWindow rootViewController]];
-    BlueShiftAlertView *pushNotificationAlertView = [[BlueShiftAlertView alloc] init];
-    pushNotificationAlertView.alertControllerDelegate = (id<BlueShiftAlertControllerDelegate>)self;
-    if (@available(iOS 8.0, *)) {
-        UIAlertController *blueShiftAlertViewController = [pushNotificationAlertView alertViewWithPushDetailsDictionary:userInfo];
-        [topViewController presentViewController:blueShiftAlertViewController animated:YES completion:nil];
+    @try {
+        if ([BlueShiftInAppNotificationHelper checkAppDelegateWindowPresent] == NO) {
+            return;
+        }
+        UIViewController *topViewController = [self topViewController:[[UIApplication sharedApplication].keyWindow rootViewController]];
+        BlueShiftAlertView *pushNotificationAlertView = [[BlueShiftAlertView alloc] init];
+        pushNotificationAlertView.alertControllerDelegate = (id<BlueShiftAlertControllerDelegate>)self;
+        if (@available(iOS 8.0, *)) {
+            UIAlertController *blueShiftAlertViewController = [pushNotificationAlertView alertViewWithPushDetailsDictionary:userInfo];
+            [topViewController presentViewController:blueShiftAlertViewController animated:YES completion:nil];
+        }
+    } @catch (NSException *exception) {
+        [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
     }
 }
 

--- a/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
+++ b/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
@@ -339,15 +339,14 @@
     self.userInfo = userInfo;
     // Handle push notification when the app is in active state...
     @try {
-        if ([BlueShiftInAppNotificationHelper checkAppDelegateWindowPresent] == NO) {
-            return;
-        }
-        UIViewController *topViewController = [self topViewController:[[UIApplication sharedApplication].keyWindow rootViewController]];
-        BlueShiftAlertView *pushNotificationAlertView = [[BlueShiftAlertView alloc] init];
-        pushNotificationAlertView.alertControllerDelegate = (id<BlueShiftAlertControllerDelegate>)self;
-        if (@available(iOS 8.0, *)) {
-            UIAlertController *blueShiftAlertViewController = [pushNotificationAlertView alertViewWithPushDetailsDictionary:userInfo];
-            [topViewController presentViewController:blueShiftAlertViewController animated:YES completion:nil];
+        if ([BlueShiftInAppNotificationHelper checkAppDelegateWindowPresent] == YES) {
+            UIViewController *topViewController = [self topViewController:[[UIApplication sharedApplication].keyWindow rootViewController]];
+            BlueShiftAlertView *pushNotificationAlertView = [[BlueShiftAlertView alloc] init];
+            pushNotificationAlertView.alertControllerDelegate = (id<BlueShiftAlertControllerDelegate>)self;
+            if (@available(iOS 8.0, *)) {
+                UIAlertController *blueShiftAlertViewController = [pushNotificationAlertView alertViewWithPushDetailsDictionary:userInfo];
+                [topViewController presentViewController:blueShiftAlertViewController animated:YES completion:nil];
+            }
         }
     } @catch (NSException *exception) {
         [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];

--- a/BlueShift-iOS-SDK/BlueShiftDeepLink.m
+++ b/BlueShift-iOS-SDK/BlueShiftDeepLink.m
@@ -87,7 +87,9 @@ static NSDictionary *_deepLinkList = nil;
         return NO;
     }
     
-    
+    if ([self checkAppDelegateWindowPresent] == NO) {
+        return  NO;
+    }
     UINavigationController *navController = (UINavigationController *)[[[UIApplication sharedApplication] delegate] window].rootViewController;
     if(navController == nil) {
         [BlueshiftLog logError:nil withDescription:@"Can not perform custom deep linking as rootViewContoller is nil" methodName:nil];
@@ -105,8 +107,10 @@ static NSDictionary *_deepLinkList = nil;
 
 
 - (void)deepLinkToPath:(NSArray *)path {
+    if ([self checkAppDelegateWindowPresent] == NO) {
+        return;
+    }
     // Method to perform deeplink using the path components array ...
-    
     // Get the current navigational controller and pop to the root view controller...
     UINavigationController *navController = (UINavigationController *)[[[UIApplication sharedApplication] delegate] window].rootViewController;
     if(navController != nil && [navController respondsToSelector:@selector(popToRootViewControllerAnimated:)]) {
@@ -131,18 +135,27 @@ static NSDictionary *_deepLinkList = nil;
 
 - (UIViewController *)lastViewController {
     // Get the last view controller in the view controller list ...
-    
+    if ([self checkAppDelegateWindowPresent] == NO) {
+        return  nil;
+    }
     UINavigationController *navController = (UINavigationController *)[[[UIApplication sharedApplication] delegate] window].rootViewController;
     return [navController.viewControllers lastObject];
 }
 
 - (UIViewController *)firstViewController {
     // Get the first view controller in view controller list ...
-    
+    if ([self checkAppDelegateWindowPresent] == NO) {
+        return  nil;
+    }
     UINavigationController *navController = (UINavigationController *)[[[UIApplication sharedApplication] delegate] window].rootViewController;
     return [navController.viewControllers firstObject];
 }
 
-
+-(BOOL)checkAppDelegateWindowPresent {
+    if ([[[UIApplication sharedApplication] delegate] window] == nil) {
+        return NO;
+    }
+    return YES;
+}
 
 @end

--- a/BlueShift-iOS-SDK/BlueShiftDeepLink.m
+++ b/BlueShift-iOS-SDK/BlueShiftDeepLink.m
@@ -6,6 +6,7 @@
 //
 #import "BlueShiftDeepLink.h"
 #import "BlueshiftLog.h"
+#import "InApps/BlueShiftInAppNotificationHelper.h"
 
 @implementation BlueShiftDeepLink
 
@@ -87,7 +88,7 @@ static NSDictionary *_deepLinkList = nil;
         return NO;
     }
     
-    if ([self checkAppDelegateWindowPresent] == NO) {
+    if ([BlueShiftInAppNotificationHelper checkAppDelegateWindowPresent] == NO) {
         return  NO;
     }
     UINavigationController *navController = (UINavigationController *)[[[UIApplication sharedApplication] delegate] window].rootViewController;
@@ -107,7 +108,7 @@ static NSDictionary *_deepLinkList = nil;
 
 
 - (void)deepLinkToPath:(NSArray *)path {
-    if ([self checkAppDelegateWindowPresent] == NO) {
+    if ([BlueShiftInAppNotificationHelper checkAppDelegateWindowPresent] == NO) {
         return;
     }
     // Method to perform deeplink using the path components array ...
@@ -135,7 +136,7 @@ static NSDictionary *_deepLinkList = nil;
 
 - (UIViewController *)lastViewController {
     // Get the last view controller in the view controller list ...
-    if ([self checkAppDelegateWindowPresent] == NO) {
+    if ([BlueShiftInAppNotificationHelper checkAppDelegateWindowPresent] == NO) {
         return  nil;
     }
     UINavigationController *navController = (UINavigationController *)[[[UIApplication sharedApplication] delegate] window].rootViewController;
@@ -144,18 +145,11 @@ static NSDictionary *_deepLinkList = nil;
 
 - (UIViewController *)firstViewController {
     // Get the first view controller in view controller list ...
-    if ([self checkAppDelegateWindowPresent] == NO) {
+    if ([BlueShiftInAppNotificationHelper checkAppDelegateWindowPresent] == NO) {
         return  nil;
     }
     UINavigationController *navController = (UINavigationController *)[[[UIApplication sharedApplication] delegate] window].rootViewController;
     return [navController.viewControllers firstObject];
-}
-
--(BOOL)checkAppDelegateWindowPresent {
-    if ([[[UIApplication sharedApplication] delegate] window] == nil) {
-        return NO;
-    }
-    return YES;
 }
 
 @end

--- a/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationHelper.h
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationHelper.h
@@ -26,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString*)getEncodedURLString:(NSString*) urlString;
 + (CGFloat)getPresentationAreaHeight;
 + (CGFloat)getPresentationAreaWidth;
++ (BOOL)checkAppDelegateWindowPresent;
 + (BOOL)isIpadDevice;
 @end
 

--- a/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationHelper.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationHelper.m
@@ -108,6 +108,13 @@ static NSDictionary *_inAppTypeDictionay;
     return presentationAreaWidth;
 }
 
++ (BOOL)checkAppDelegateWindowPresent {
+    if (![[UIApplication sharedApplication].delegate respondsToSelector:@selector(window)]) {
+        return NO;
+    }
+    return YES;
+}
+
 + (NSString*)getEncodedURLString:(NSString*) urlString {
     if (urlString && ![urlString isEqualToString:@""]) {
         NSString *charactersToEscape = @"!*'();:@&=+$,/?%#[]<>^`\{|}"" ";


### PR DESCRIPTION
For sceneDelegate configured app, appDelegate window object is not present. Add appDelegate window object check so that app should not crash if window object is not present.