### PR TITLE
MOBL-517 Slide-in not getting displayed if label height is below 50

### DIFF
--- a/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationConstant.h
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationConstant.h
@@ -100,6 +100,7 @@
 /* Define size of view */
 #define kInAppNotificationModalIconWidth                        50.0
 #define kInAppNotificationModalIconHeight                       50.0
+#define kSlideInInAppNotificationMinimumHeight                  50.0
 #define kInAppNotificationModalYPadding                         10.0
 #define kInAppNotificationModalTitleHeight                      40.0
 #define kInAppNotificationSlideBannerXPadding                   20.0

--- a/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationHelper.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationHelper.m
@@ -59,13 +59,13 @@ static NSDictionary *_inAppTypeDictionay;
 
 + (CGFloat)convertPointsHeightToPercentage:(float) height {
     CGFloat presentationAreaHeight = [self getPresentationAreaHeight];
-    CGFloat heightInPercentage = (CGFloat) ceil(((height/presentationAreaHeight) * 100.0f));
+    CGFloat heightInPercentage = (CGFloat) (((height/presentationAreaHeight) * 100.0f));
     return heightInPercentage;
 }
 
 + (CGFloat)convertPointsWidthToPercentage:(float) width {
     CGFloat presentationAreaWidth = [self getPresentationAreaWidth];
-    CGFloat widthInPercentage = (CGFloat) ceil(((width/presentationAreaWidth) * 100.0f));
+    CGFloat widthInPercentage = (CGFloat) (((width/presentationAreaWidth) * 100.0f));
     return  widthInPercentage;
 }
 

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationSlideBannerViewController.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationSlideBannerViewController.m
@@ -178,13 +178,20 @@
             CGFloat messageBottomPadding = (messagePadding && messagePadding.bottom > 0) ? messagePadding.bottom : 0.0;
             CGFloat descriptionLabelHeight = descriptionLabel.frame.size.height + (messageTopPadding + messageBottomPadding);
             
-            if (descriptionLabelHeight < 50) {
-                descriptionLabelHeight = iconLabel.frame.size.height > 0 ? iconLabel.frame.size.height : imageView.frame.size.height;
-                //Modify height of description label if height is less than 50
-                //to align text veritically center
-                CGRect derscriptionLabelFrame = descriptionLabel.frame;
-                derscriptionLabelFrame.size.height = descriptionLabelHeight - messageTopPadding - messageBottomPadding;
-                descriptionLabel.frame = derscriptionLabelFrame;
+            // Set height to icon height/image height/default min height if label height is less than min height
+            // to align text veritically center
+            if (descriptionLabelHeight < kSlideInInAppNotificationMinimumHeight) {
+                if (iconLabel.frame.size.height > 0) {
+                    descriptionLabelHeight = iconLabel.frame.size.height;
+                } else if (imageView.frame.size.height > 0) {
+                    descriptionLabelHeight = imageView.frame.size.height;
+                } else {
+                    descriptionLabelHeight = kSlideInInAppNotificationMinimumHeight;
+                }
+                
+                CGRect descriptionLabelFrame = descriptionLabel.frame;
+                descriptionLabelFrame.size.height = descriptionLabelHeight - messageTopPadding - messageBottomPadding;
+                descriptionLabel.frame = descriptionLabelFrame;
             }
             
             CGRect frame = slideBannerView.frame;


### PR DESCRIPTION
Added condition to set description label size to default 50 if icon or image is not present
Removed ceiling conversion for percentage height and percentage width value