### PR TITLE
Release/v2.1.9

### DIFF
--- a/BlueShift-iOS-SDK/BlueShiftAppData.m
+++ b/BlueShift-iOS-SDK/BlueShiftAppData.m
@@ -49,8 +49,15 @@ static BlueShiftAppData *_currentAppData = nil;
 }
 
 - (void)setEnablePush:(BOOL)enablePush {
-    NSString *val = enablePush ? kYES : kNO;
-    [[NSUserDefaults standardUserDefaults] setObject:val forKey:kBlueshiftEnablePush];
+    // Added try catch to avoid issues with App UI automation script execution
+    @try {
+        NSString *val = enablePush ? kYES : kNO;
+        NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+        [defaults setObject:val forKey:kBlueshiftEnablePush];
+        [defaults synchronize];
+    } @catch (NSException *exception) {
+        [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
+    }
 }
 
 - (NSDictionary *)toDictionary {

--- a/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
+++ b/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
@@ -146,8 +146,14 @@
 }
 
 - (void)setLastModifiedUNAuthorizationStatus:(NSString*) authorizationStatus {
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    [defaults setObject:authorizationStatus forKey:kBlueshiftUNAuthorizationStatus];
+    // Added try catch to avoid issues with App UI automation script execution
+    @try {
+        NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+        [defaults setObject:authorizationStatus forKey:kBlueshiftUNAuthorizationStatus];
+        [defaults synchronize];
+    } @catch (NSException *exception) {
+        [BlueshiftLog logException:exception withDescription:nil methodName:nil];
+    }
 }
 
 /// Check current UNAuthorizationStatus status with last Modified UNAuthorizationStatus status, if its not matching

--- a/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
+++ b/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
@@ -153,7 +153,7 @@
         [defaults setObject:authorizationStatus forKey:kBlueshiftUNAuthorizationStatus];
         [defaults synchronize];
     } @catch (NSException *exception) {
-        [BlueshiftLog logException:exception withDescription:nil methodName:nil];
+        [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
     }
 }
 

--- a/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
+++ b/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
@@ -12,6 +12,7 @@
 #import "BlueShiftInAppNotificationConstant.h"
 #import "BlueshiftLog.h"
 #import "BlueshiftConstants.h"
+#import "InApps/BlueShiftInAppNotificationHelper.h"
 
 #define SYSTEM_VERSION_GRATERTHAN_OR_EQUALTO(v) ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedAscending)
 
@@ -343,12 +344,18 @@
     [self trackPushViewedWithParameters:userInfo];
     self.userInfo = userInfo;
     // Handle push notification when the app is in active state...
-    UIViewController *topViewController = [self topViewController:[[UIApplication sharedApplication].keyWindow rootViewController]];
-    BlueShiftAlertView *pushNotificationAlertView = [[BlueShiftAlertView alloc] init];
-    pushNotificationAlertView.alertControllerDelegate = (id<BlueShiftAlertControllerDelegate>)self;
-    if (@available(iOS 8.0, *)) {
-        UIAlertController *blueShiftAlertViewController = [pushNotificationAlertView alertViewWithPushDetailsDictionary:userInfo];
-        [topViewController presentViewController:blueShiftAlertViewController animated:YES completion:nil];
+    @try {
+        if ([BlueShiftInAppNotificationHelper checkAppDelegateWindowPresent] == YES) {
+            UIViewController *topViewController = [self topViewController:[[UIApplication sharedApplication].keyWindow rootViewController]];
+            BlueShiftAlertView *pushNotificationAlertView = [[BlueShiftAlertView alloc] init];
+            pushNotificationAlertView.alertControllerDelegate = (id<BlueShiftAlertControllerDelegate>)self;
+            if (@available(iOS 8.0, *)) {
+                UIAlertController *blueShiftAlertViewController = [pushNotificationAlertView alertViewWithPushDetailsDictionary:userInfo];
+                [topViewController presentViewController:blueShiftAlertViewController animated:YES completion:nil];
+            }
+        }
+    } @catch (NSException *exception) {
+        [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
     }
 }
 

--- a/BlueShift-iOS-SDK/BlueShiftDeepLink.m
+++ b/BlueShift-iOS-SDK/BlueShiftDeepLink.m
@@ -135,12 +135,20 @@ static NSDictionary *_deepLinkList = nil;
 }
 
 - (UIViewController *)lastViewController {
-    // Get the last view controller in the view controller list ...
-    if ([BlueShiftInAppNotificationHelper checkAppDelegateWindowPresent] == NO) {
-        return  nil;
+    @try {
+        if ([BlueShiftInAppNotificationHelper checkAppDelegateWindowPresent] == NO) {
+            return  nil;
+        }
+        if (![[[[UIApplication sharedApplication] delegate] window] respondsToSelector:@selector(rootViewController)]) {
+            return  nil;
+        }
+        // Get the last view controller in the view controller list ...
+        UINavigationController *navController = (UINavigationController *)[[[UIApplication sharedApplication] delegate] window].rootViewController;
+        return [navController.viewControllers lastObject];
+    } @catch (NSException *exception) {
+        [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
     }
-    UINavigationController *navController = (UINavigationController *)[[[UIApplication sharedApplication] delegate] window].rootViewController;
-    return [navController.viewControllers lastObject];
+    return  nil;
 }
 
 - (UIViewController *)firstViewController {

--- a/BlueShift-iOS-SDK/BlueShiftDeepLink.m
+++ b/BlueShift-iOS-SDK/BlueShiftDeepLink.m
@@ -6,6 +6,7 @@
 //
 #import "BlueShiftDeepLink.h"
 #import "BlueshiftLog.h"
+#import "InApps/BlueShiftInAppNotificationHelper.h"
 
 @implementation BlueShiftDeepLink
 
@@ -87,7 +88,9 @@ static NSDictionary *_deepLinkList = nil;
         return NO;
     }
     
-    
+    if ([BlueShiftInAppNotificationHelper checkAppDelegateWindowPresent] == NO) {
+        return  NO;
+    }
     UINavigationController *navController = (UINavigationController *)[[[UIApplication sharedApplication] delegate] window].rootViewController;
     if(navController == nil) {
         [BlueshiftLog logError:nil withDescription:@"Can not perform custom deep linking as rootViewContoller is nil" methodName:nil];
@@ -105,8 +108,10 @@ static NSDictionary *_deepLinkList = nil;
 
 
 - (void)deepLinkToPath:(NSArray *)path {
+    if ([BlueShiftInAppNotificationHelper checkAppDelegateWindowPresent] == NO) {
+        return;
+    }
     // Method to perform deeplink using the path components array ...
-    
     // Get the current navigational controller and pop to the root view controller...
     UINavigationController *navController = (UINavigationController *)[[[UIApplication sharedApplication] delegate] window].rootViewController;
     if(navController != nil && [navController respondsToSelector:@selector(popToRootViewControllerAnimated:)]) {
@@ -131,18 +136,20 @@ static NSDictionary *_deepLinkList = nil;
 
 - (UIViewController *)lastViewController {
     // Get the last view controller in the view controller list ...
-    
+    if ([BlueShiftInAppNotificationHelper checkAppDelegateWindowPresent] == NO) {
+        return  nil;
+    }
     UINavigationController *navController = (UINavigationController *)[[[UIApplication sharedApplication] delegate] window].rootViewController;
     return [navController.viewControllers lastObject];
 }
 
 - (UIViewController *)firstViewController {
     // Get the first view controller in view controller list ...
-    
+    if ([BlueShiftInAppNotificationHelper checkAppDelegateWindowPresent] == NO) {
+        return  nil;
+    }
     UINavigationController *navController = (UINavigationController *)[[[UIApplication sharedApplication] delegate] window].rootViewController;
     return [navController.viewControllers firstObject];
 }
-
-
 
 @end

--- a/BlueShift-iOS-SDK/HttpRequestOperationEntity.m
+++ b/BlueShift-iOS-SDK/HttpRequestOperationEntity.m
@@ -56,10 +56,18 @@
                     NSError *error = nil;
                     [context save:&error];
                     if(masterContext && [masterContext isKindOfClass:[NSManagedObjectContext class]]) {
-                        [masterContext performBlock:^{
-                            NSError *error = nil;
-                            [masterContext save:&error];
-                        }];
+                        @try {
+                            [masterContext performBlock:^{
+                                @try {
+                                    NSError *error = nil;
+                                    [masterContext save:&error];
+                                } @catch (NSException *exception) {
+                                    [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
+                                }
+                            }];
+                        } @catch (NSException *exception) {
+                            [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
+                        }
                     }
                 }];
             }

--- a/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationConstant.h
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationConstant.h
@@ -100,6 +100,7 @@
 /* Define size of view */
 #define kInAppNotificationModalIconWidth                        50.0
 #define kInAppNotificationModalIconHeight                       50.0
+#define kSlideInInAppNotificationMinimumHeight                  50.0
 #define kInAppNotificationModalYPadding                         10.0
 #define kInAppNotificationModalTitleHeight                      40.0
 #define kInAppNotificationSlideBannerXPadding                   20.0

--- a/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationHelper.h
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationHelper.h
@@ -26,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString*)getEncodedURLString:(NSString*) urlString;
 + (CGFloat)getPresentationAreaHeight;
 + (CGFloat)getPresentationAreaWidth;
++ (BOOL)checkAppDelegateWindowPresent;
 + (BOOL)isIpadDevice;
 @end
 

--- a/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationHelper.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationHelper.m
@@ -108,6 +108,13 @@ static NSDictionary *_inAppTypeDictionay;
     return presentationAreaWidth;
 }
 
++ (BOOL)checkAppDelegateWindowPresent {
+    if (![[UIApplication sharedApplication].delegate respondsToSelector:@selector(window)]) {
+        return NO;
+    }
+    return YES;
+}
+
 + (NSString*)getEncodedURLString:(NSString*) urlString {
     if (urlString && ![urlString isEqualToString:@""]) {
         NSString *charactersToEscape = @"!*'();:@&=+$,/?%#[]<>^`\{|}"" ";

--- a/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationHelper.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationHelper.m
@@ -59,13 +59,13 @@ static NSDictionary *_inAppTypeDictionay;
 
 + (CGFloat)convertPointsHeightToPercentage:(float) height {
     CGFloat presentationAreaHeight = [self getPresentationAreaHeight];
-    CGFloat heightInPercentage = (CGFloat) ceil(((height/presentationAreaHeight) * 100.0f));
+    CGFloat heightInPercentage = (CGFloat) (((height/presentationAreaHeight) * 100.0f));
     return heightInPercentage;
 }
 
 + (CGFloat)convertPointsWidthToPercentage:(float) width {
     CGFloat presentationAreaWidth = [self getPresentationAreaWidth];
-    CGFloat widthInPercentage = (CGFloat) ceil(((width/presentationAreaWidth) * 100.0f));
+    CGFloat widthInPercentage = (CGFloat) (((width/presentationAreaWidth) * 100.0f));
     return  widthInPercentage;
 }
 

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationModalViewController.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationModalViewController.m
@@ -237,7 +237,7 @@
     
     UIImageView *imageView = [[UIImageView alloc] initWithFrame: cgRect];
     if (self.notification.notificationContent.banner) {
-        [self loadImageFromURL: imageView andImageURL: self.notification.notificationContent.banner andWidth: imageViewWidth andHeight: imageViewHeight];
+        [self loadImageFromURL:self.notification.notificationContent.banner forImageView:imageView];
     }
     
     imageView.contentMode = UIViewContentModeScaleToFill;

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationSlideBannerViewController.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationSlideBannerViewController.m
@@ -178,13 +178,20 @@
             CGFloat messageBottomPadding = (messagePadding && messagePadding.bottom > 0) ? messagePadding.bottom : 0.0;
             CGFloat descriptionLabelHeight = descriptionLabel.frame.size.height + (messageTopPadding + messageBottomPadding);
             
-            if (descriptionLabelHeight < 50) {
-                descriptionLabelHeight = iconLabel.frame.size.height > 0 ? iconLabel.frame.size.height : imageView.frame.size.height;
-                //Modify height of description label if height is less than 50
-                //to align text veritically center
-                CGRect derscriptionLabelFrame = descriptionLabel.frame;
-                derscriptionLabelFrame.size.height = descriptionLabelHeight - messageTopPadding - messageBottomPadding;
-                descriptionLabel.frame = derscriptionLabelFrame;
+            // Set height to icon height/image height/default min height if label height is less than min height
+            // to align text veritically center
+            if (descriptionLabelHeight < kSlideInInAppNotificationMinimumHeight) {
+                if (iconLabel.frame.size.height > 0) {
+                    descriptionLabelHeight = iconLabel.frame.size.height;
+                } else if (imageView.frame.size.height > 0) {
+                    descriptionLabelHeight = imageView.frame.size.height;
+                } else {
+                    descriptionLabelHeight = kSlideInInAppNotificationMinimumHeight;
+                }
+                
+                CGRect descriptionLabelFrame = descriptionLabel.frame;
+                descriptionLabelFrame.size.height = descriptionLabelHeight - messageTopPadding - messageBottomPadding;
+                descriptionLabel.frame = descriptionLabelFrame;
             }
             
             CGRect frame = slideBannerView.frame;

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationSlideBannerViewController.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationSlideBannerViewController.m
@@ -227,7 +227,7 @@
     
     UIImageView *imageView = [[UIImageView alloc] initWithFrame: cgRect];
     if (self.notification.notificationContent.iconImage) {
-       [self loadImageFromURL: imageView andImageURL: self.notification.notificationContent.iconImage andWidth:kInAppNotificationModalIconWidth andHeight:kInAppNotificationModalIconHeight];
+       [self loadImageFromURL:self.notification.notificationContent.iconImage forImageView:imageView];
     }
     
     if (self.notification.contentStyle && self.notification.contentStyle.iconImageBackgroundColor != (id)[NSNull null] && self.notification.contentStyle.iconImageBackgroundColor.length > 0) {

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationViewController.h
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationViewController.h
@@ -41,7 +41,7 @@ controller;
 - (void)configureBackground;
 - (UIColor *)colorWithHexString:(NSString *)str;
 - (void)loadNotificationView;
-- (void)loadImageFromURL:(UIImageView *)imageView andImageURL:(NSString *)imageURL andWidth:(double)width andHeight:(double)height;
+- (void)loadImageFromURL:(NSString *)imageURL forImageView:(UIImageView *)imageView;
 - (void)setLabelText:(UILabel *)label andString:(NSString *)value labelColor:(NSString *)labelColorCode backgroundColor:(NSString *)backgroundColorCode;
 - (void)applyIconToLabelView:(UILabel *)iconLabelView andFontIconSize:(NSNumber *)fontSize;
 - (void)handleActionButtonNavigation:(BlueShiftInAppNotificationButton *)buttonDetails;

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationViewController.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationViewController.m
@@ -100,21 +100,14 @@
     return [UIColor colorWithRed:(float)r/255.0f green:(float)g/255.0f blue:(float)b/255.0f alpha:1];
 }
 
-- (void)loadImageFromURL:(UIImageView *)imageView andImageURL:(NSString *)imageURL andWidth:(double)width andHeight:(double)height{
+
+/// Download and load image in imageView
+/// @param imageURL Image url to download the image
+/// @param imageView  assign the downloaded image to imageView
+- (void)loadImageFromURL:(NSString *)imageURL forImageView:(UIImageView *)imageView {
     UIImage *image = [[UIImage alloc] initWithData:[self loadAndCacheImageForURLString:imageURL]];
-    
-    // resize image
-    CGSize newSize = CGSizeMake(imageView.frame.size.width, imageView.frame.size.height);
-    UIGraphicsBeginImageContext(newSize);// a CGSize that has the size you want
-    CGFloat xPosition = (imageView.frame.size.width / 2) - (width / 2);
-    CGFloat yPosition = (imageView.frame.size.height / 2) - (height / 2);
-    [image drawInRect:CGRectMake(xPosition, yPosition, width, height)];
-    
-    //image is the original UIImage
-    UIImage* newImage = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
-    
-    imageView.image = newImage;
+    imageView.contentMode = UIViewContentModeScaleAspectFit;
+    imageView.image = image;
 }
 
 - (void)setBackgroundImageFromURL:(UIView *)notificationView {

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationViewController.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationViewController.m
@@ -106,7 +106,6 @@
 /// @param imageView  assign the downloaded image to imageView
 - (void)loadImageFromURL:(NSString *)imageURL forImageView:(UIImageView *)imageView {
     UIImage *image = [[UIImage alloc] initWithData:[self loadAndCacheImageForURLString:imageURL]];
-    imageView.contentMode = UIViewContentModeScaleAspectFit;
     imageView.image = image;
 }
 


### PR DESCRIPTION
MOBL-513 - Added try-catch block to avoid issues with App UI automation script execution
MOBL-479 - crash on core data save
MOBL-486 - Add appDelegate window object check
MOBL-517  - Added condition to set description label size to default 50 if icon or image is not present, removed ceil conversion for percentage value 
MOBL-516 Slide-in fuzzy image issue 
MOBL-511 Added check to see if rootviewcontroller is present in the window object.