### PR TITLE
Release/v2.1.18

### DIFF
--- a/BlueShift-iOS-Extension-SDK/BlueShiftPushAnalytics.m
+++ b/BlueShift-iOS-Extension-SDK/BlueShiftPushAnalytics.m
@@ -25,6 +25,8 @@
             [parameterMutableDictionary addEntriesFromDictionary:pushTrackParameterDictionary];
         }
         [parameterMutableDictionary setObject:type forKey:@"a"];
+        NSString *browserPlatform = [NSString stringWithFormat:@"%@ %@", kiOS, [[UIDevice currentDevice] systemVersion]];
+        [parameterMutableDictionary setObject:browserPlatform forKey:kBrowserPlatform];
         NSString *url = [NSString stringWithFormat:@"%@%@", kBaseURL, kPushEventsUploadURL];
         [self fireAPICallWithURL:url data:parameterMutableDictionary andRetryCount:3];
     }

--- a/BlueShift-iOS-Extension-SDK/BlueShiftPushNotification.m
+++ b/BlueShift-iOS-Extension-SDK/BlueShiftPushNotification.m
@@ -46,7 +46,7 @@ static BlueShiftPushNotification *_sharedInstance = nil;
         NSLog(@"[Blueshift] Error - Please set the api key in the Notification Service Extension, otherwise push notification delivered events will not reflect on the dashboard");
     }
     
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
         [self trackPushViewedWithRequest:request];
     });
     

--- a/BlueShift-iOS-Extension-SDK/BlueshiftExtensionConstants.h
+++ b/BlueShift-iOS-Extension-SDK/BlueshiftExtensionConstants.h
@@ -51,5 +51,7 @@
 
 #define kAppName                                                        @"app_name"
 #define kDeviceID                                                       @"device_id"
+#define kBrowserPlatform                                                @"browser_platform"
+#define kiOS                                                            @"iOS"
 
 #endif

--- a/BlueShift-iOS-SDK/BlueShift.h
+++ b/BlueShift-iOS-SDK/BlueShift.h
@@ -47,6 +47,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property BlueShiftAppDelegate * _Nullable appDelegate;
 @property BlueShiftUserNotificationCenterDelegate * _Nullable userNotificationDelegate;
 
+/// Image cache for storing downloaded images from the in-app notifications. The cache will be cleared when in-app gets dismissed.
+@property (nonatomic, strong) NSCache<NSString*, NSData *> *inAppImageDataCache;
+
 + (instancetype _Nullable)sharedInstance;
 
 /// Initialise the SDK using BlueShiftConfig

--- a/BlueShift-iOS-SDK/BlueShift.m
+++ b/BlueShift-iOS-SDK/BlueShift.m
@@ -667,12 +667,11 @@ static BlueShift *_sharedBlueShiftInstance = nil;
     if([self validateSDKTrackingRequirements] == false) {
         return;
     }
-    
-    parameters[kBrowserPlatform] = [BlueShiftDeviceData currentDeviceData].operatingSystem;
-    
     if (parameters != nil) {
+        NSMutableDictionary* mutableParams = [parameters mutableCopy];
+        [mutableParams setValue:[BlueShiftDeviceData currentDeviceData].operatingSystem forKey:kBrowserPlatform];
         NSString *url = [NSString stringWithFormat:@"%@%@", kBaseURL, kPushEventsUploadURL];
-        BlueShiftRequestOperation *requestOperation = [[BlueShiftRequestOperation alloc] initWithRequestURL:url andHttpMethod:BlueShiftHTTPMethodGET andParameters:[parameters copy] andRetryAttemptsCount:kRequestTryMaximumLimit andNextRetryTimeStamp:0 andIsBatchEvent:isBatchEvent];
+        BlueShiftRequestOperation *requestOperation = [[BlueShiftRequestOperation alloc] initWithRequestURL:url andHttpMethod:BlueShiftHTTPMethodGET andParameters:[mutableParams copy] andRetryAttemptsCount:kRequestTryMaximumLimit andNextRetryTimeStamp:0 andIsBatchEvent:isBatchEvent];
         [BlueShiftRequestQueue addRequestOperation:requestOperation];
     }
 }

--- a/BlueShift-iOS-SDK/BlueShift.m
+++ b/BlueShift-iOS-SDK/BlueShift.m
@@ -110,10 +110,11 @@ static BlueShift *_sharedBlueShiftInstance = nil;
     }
     if (config.enablePushNotification == YES) {
         [blueShiftAppDelegate registerForNotification];
-        [blueShiftAppDelegate handleRemoteNotificationOnLaunchWithLaunchOptions:config.applicationLaunchOptions];
     } else if (config.enableSilentPushNotification == YES) {
         [blueShiftAppDelegate registerForSilentPushNotification];
     }
+    [blueShiftAppDelegate handleRemoteNotificationOnLaunchWithLaunchOptions:config.applicationLaunchOptions];
+    
     // Initialize In App Manager
     _inAppNotificationMananger = [[BlueShiftInAppNotificationManager alloc] init];
     if (config.inAppNotificationDelegate) {
@@ -666,7 +667,9 @@ static BlueShift *_sharedBlueShiftInstance = nil;
     if([self validateSDKTrackingRequirements] == false) {
         return;
     }
-
+    
+    parameters[kBrowserPlatform] = [BlueShiftDeviceData currentDeviceData].operatingSystem;
+    
     if (parameters != nil) {
         NSString *url = [NSString stringWithFormat:@"%@%@", kBaseURL, kPushEventsUploadURL];
         BlueShiftRequestOperation *requestOperation = [[BlueShiftRequestOperation alloc] initWithRequestURL:url andHttpMethod:BlueShiftHTTPMethodGET andParameters:[parameters copy] andRetryAttemptsCount:kRequestTryMaximumLimit andNextRetryTimeStamp:0 andIsBatchEvent:isBatchEvent];

--- a/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
+++ b/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
@@ -425,7 +425,7 @@
         }
         if ([self.oldDelegate respondsToSelector:@selector(application:openURL:options:)]) {
             if (@available(iOS 9.0, *)) {
-                NSDictionary *pushOptions = @{openURLOptionsSource:openURLOptionsBlueshift,openURLOptionsChannel:openURLOptionsPush};
+                NSDictionary *pushOptions = @{openURLOptionsSource:openURLOptionsBlueshift,openURLOptionsChannel:openURLOptionsPush,openURLOptionsPushUserInfo:userInfo};
                 [self.oldDelegate application:[UIApplication sharedApplication] openURL: deepLinkURL options:pushOptions];
                 [BlueshiftLog logInfo:[NSString stringWithFormat:@"%@ %@",@"Delivered push notification deeplink to AppDelegate openURL method, Deep link - ", [deepLinkURL absoluteString]] withDetails: pushOptions methodName:nil];
             }

--- a/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
+++ b/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
@@ -16,7 +16,9 @@
 
 #define SYSTEM_VERSION_GRATERTHAN_OR_EQUALTO(v) ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedAscending)
 
-@implementation BlueShiftAppDelegate
+@implementation BlueShiftAppDelegate {
+    NSString *lastProcessedPushNotificationUUID;
+}
 
 - (id) init {
     self = [super init];
@@ -78,12 +80,11 @@
 
 // Handles the push notification payload when the app is killed and lauched from push notification tray ...
 - (BOOL)handleRemoteNotificationOnLaunchWithLaunchOptions:(NSDictionary *)launchOptions {
-    NSDictionary *userInfo = [launchOptions objectForKey:UIApplicationLaunchOptionsRemoteNotificationKey];
-
-    if (userInfo) {
-        // Handling the push notification if we get the userInfo from launchOptions ...
-        // It's the only way to track notification payload while app is on launch (i.e after the app is killed) ...
-        [self handleRemoteNotification:userInfo];
+    if (launchOptions) {
+        NSDictionary *userInfo = [launchOptions objectForKey:UIApplicationLaunchOptionsRemoteNotificationKey];
+        if (userInfo) {
+            [self handleRemoteNotification:userInfo];
+        }
     }
     
     return YES;
@@ -378,7 +379,12 @@
     if ([BlueshiftEventAnalyticsHelper isSilenPushNotificationPayload: userInfo]) {
         [[BlueShift sharedInstance] handleSilentPushNotification: userInfo forApplicationState: UIApplicationStateActive];
     } else {
+        NSString *pushUUID = [userInfo valueForKey:kInAppNotificationModalMessageUDIDKey];
         NSString *pushCategory = [[userInfo objectForKey: kNotificationAPSIdentifierKey] objectForKey: kNotificationCategoryIdentifierKey];
+        if ([pushCategory isEqualToString:kNotificationCategorySilentPushIdentifier] || [pushUUID isEqualToString:lastProcessedPushNotificationUUID]) {
+            [BlueshiftLog logInfo:@"Skipped processing notification due to one of the following reasons." withDetails:@"1. The push notification is silent push notification 2. The push notification click is already processed." methodName:nil];
+            return;
+        }
         self.pushAlertDictionary = [userInfo objectForKey: kNotificationAPSIdentifierKey];
         self.userInfo = userInfo;
         NSDictionary *pushTrackParameterDictionary = [BlueshiftEventAnalyticsHelper pushTrackParameterDictionaryForPushDetailsDictionary:userInfo];
@@ -416,6 +422,8 @@
         [[[BlueShift sharedInstance].config blueShiftPushDelegate] pushNotificationDidClick:userInfo];
     }
 
+    lastProcessedPushNotificationUUID = [userInfo valueForKey:kInAppNotificationModalMessageUDIDKey];
+    
     [self trackAppOpenWithParameters:userInfo];
 
     if (userInfo != nil && ([userInfo objectForKey: kPushNotificationDeepLinkURLKey] || [userInfo objectForKey: kNotificationURLElementKey])) {
@@ -473,6 +481,11 @@
         } else if([BlueshiftEventAnalyticsHelper isSchedulePushNotification:userInfo]) {
             [self validateAndScheduleLocalNotification:userInfo];
         } else {
+            NSString *pushUUID = [userInfo valueForKey:kInAppNotificationModalMessageUDIDKey];
+            if ([pushCategory isEqualToString:kNotificationCategorySilentPushIdentifier] || [pushUUID isEqualToString:lastProcessedPushNotificationUUID]) {
+                [BlueshiftLog logInfo:@"Skipped processing notification due to following reasons" withDetails:@"1. The push notification is silent push notification 2. The push notification click is already processed." methodName:nil];
+                return;
+            }
             // Handle push notification when the app is in inactive or background state ...
             if ([pushCategory isEqualToString:kNotificationCategoryBuyIdentifier]) {
                 [self handleCategoryForBuyUsingPushDetailsDictionary:userInfo];

--- a/BlueShift-iOS-SDK/BlueShiftNotificationConstants.h
+++ b/BlueShift-iOS-SDK/BlueShiftNotificationConstants.h
@@ -33,7 +33,7 @@
 #define kNotificationCategoryViewCartIdentifier                         @"view_cart"
 #define kNotificationActionOpenCartIdentifier                           @"open_cart"
 
-#define kNotificationCategorySilentPushIdentifier                       @"silent_push"
+#define kNotificationCategorySilentPushIdentifier                       @"silent push"
 #define kNotificationCategoryOfferIdentifier                            @"promotion"
 #define kNotificationProductIDIdenfierKey                               @"product_id"
 #define kNotificationSelectedIndexKey                                   @"selected_index"

--- a/BlueShift-iOS-SDK/BlueShiftNotificationConstants.h
+++ b/BlueShift-iOS-SDK/BlueShiftNotificationConstants.h
@@ -33,6 +33,7 @@
 #define kNotificationCategoryViewCartIdentifier                         @"view_cart"
 #define kNotificationActionOpenCartIdentifier                           @"open_cart"
 
+#define kNotificationCategorySilentPushIdentifier                       @"silent_push"
 #define kNotificationCategoryOfferIdentifier                            @"promotion"
 #define kNotificationProductIDIdenfierKey                               @"product_id"
 #define kNotificationSelectedIndexKey                                   @"selected_index"

--- a/BlueShift-iOS-SDK/BlueShiftUserInfo.h
+++ b/BlueShift-iOS-SDK/BlueShiftUserInfo.h
@@ -12,37 +12,37 @@
 
 /// Set user email id.
 /// Make sure you call BlueShiftUserInfo.sharedInstance()?.save() after setting/modifying any property of user info.
-@property (nonatomic, strong) NSString *email;
+@property (nonatomic, strong) NSString* _Nullable email;
 
 /// Set user customer id.
 /// Make sure you call BlueShiftUserInfo.sharedInstance()?.save() after setting/modifying any property of user info.
-@property (nonatomic, strong) NSString *retailerCustomerID;
+@property (nonatomic, strong) NSString* _Nullable retailerCustomerID;
 
-@property (nonatomic, strong) NSString *name;
-@property (nonatomic, strong) NSString *firstName;
-@property (nonatomic, strong) NSString *lastName;
+@property (nonatomic, strong) NSString* _Nullable name;
+@property (nonatomic, strong) NSString* _Nullable firstName;
+@property (nonatomic, strong) NSString* _Nullable lastName;
 
-@property (nonatomic, strong) NSDate *dateOfBirth;
-@property (nonatomic, strong) NSString *gender;
-@property (nonatomic, strong) NSString *education;
+@property (nonatomic, strong) NSDate* _Nullable dateOfBirth;
+@property (nonatomic, strong) NSString* _Nullable gender;
+@property (nonatomic, strong) NSString* _Nullable education;
 
-@property (nonatomic, strong) NSDate *joinedAt;
+@property (nonatomic, strong) NSDate* _Nullable joinedAt;
 
-@property (nonatomic, strong) NSString *facebookID;
+@property (nonatomic, strong) NSString* _Nullable facebookID;
 
 /// Unsubscribe from the push notifications.
 /// Set this flag to true if you want to stop receiving push notifications for that user.
-@property NSNumber* unsubscribed;
+@property NSNumber* _Nullable  unsubscribed;
 
 /// The data stored in the additionalUserInfo will be populated on server with `additional_user_info__` prefix to every key name.
 /// If key is stored as `profession`, then server will popluate it as `additional_user_info__profession` in the events.
 /// Make sure you call BlueShiftUserInfo.sharedInstance()?.save() after setting/modifying the user info.
-@property NSDictionary *additionalUserInfo;
+@property NSMutableDictionary* _Nullable additionalUserInfo;
 
 /// The data stored in the extras will be sent to server as it is as part of every event.
 /// If key is stored as `profession`, then server will populate it as `profession` in the events.
 /// Make sure you call BlueShiftUserInfo.sharedInstance()?.save() after setting/modifying the user info.
-@property NSDictionary *extras;
+@property NSMutableDictionary* _Nullable extras;
 
 /// Call save method after making any change in the BlueshiftUserInfo data to store the data.
 - (void)save;
@@ -50,10 +50,10 @@
 /// Use this method to erase the stored data.
 + (void)removeCurrentUserInfo;
 
-+ (instancetype) sharedInstance;
++ (instancetype _Nullable) sharedInstance;
 
 /// Returns saved User info as dictionary of key value pairs
-- (NSDictionary *)toDictionary;
+- (NSDictionary *_Nonnull)toDictionary;
 
 @end
 

--- a/BlueShift-iOS-SDK/BlueShiftUserInfo.h
+++ b/BlueShift-iOS-SDK/BlueShiftUserInfo.h
@@ -31,7 +31,8 @@
 @property (nonatomic, strong) NSString *facebookID;
 
 /// Unsubscribe from the push notifications.
-@property BOOL unsubscribed;
+/// Set this flag to true if you want to stop receiving push notifications for that user.
+@property NSNumber* unsubscribed;
 
 /// The data stored in the additionalUserInfo will be populated on server with `additional_user_info__` prefix to every key name.
 /// If key is stored as `profession`, then server will popluate it as `additional_user_info__profession` in the events.

--- a/BlueShift-iOS-SDK/BlueShiftUserInfo.m
+++ b/BlueShift-iOS-SDK/BlueShiftUserInfo.m
@@ -58,7 +58,9 @@ static BlueShiftUserInfo *_sharedUserInfo = nil;
         }
         [BlueshiftEventAnalyticsHelper addToDictionary:sharedUserInfoMutableDictionary key:kBSUserFacebookId value:self.facebookID];
         [BlueshiftEventAnalyticsHelper addToDictionary:sharedUserInfoMutableDictionary key:kBSUserEducation value:self.education];
-        [BlueshiftEventAnalyticsHelper addToDictionary:sharedUserInfoMutableDictionary key:kBSUserUnsubscribedPush value:[NSNumber numberWithBool:self.unsubscribed]];
+        if (self.unsubscribed != nil) {
+            [BlueshiftEventAnalyticsHelper addToDictionary:sharedUserInfoMutableDictionary key:kBSUserUnsubscribedPush value:self.unsubscribed];
+        }
         [BlueshiftEventAnalyticsHelper addToDictionary:sharedUserInfoMutableDictionary key:kBSUserAdditionalInfo value:self.additionalUserInfo];
         if (self.dateOfBirth) {
             NSNumber *dateOfBirthTimeStamp = [NSNumber numberWithDouble:[self.dateOfBirth timeIntervalSinceReferenceDate]];
@@ -136,8 +138,8 @@ static BlueShiftUserInfo *_sharedUserInfo = nil;
             blueShiftUserInfo.education = [currentUserInfoDictionary objectForKey:kBSUserEducation];
             blueShiftUserInfo.facebookID = [currentUserInfoDictionary objectForKey:kBSUserFacebookId];
             blueShiftUserInfo.gender = [currentUserInfoDictionary objectForKey:kBSUserGender];
-            if([currentUserInfoDictionary objectForKey:kBSUserUnsubscribedPush]) {
-                blueShiftUserInfo.unsubscribed = [[currentUserInfoDictionary objectForKey:kBSUserUnsubscribedPush] boolValue];
+            if([currentUserInfoDictionary objectForKey:kBSUserUnsubscribedPush] != nil) {
+                blueShiftUserInfo.unsubscribed = (NSNumber*)[currentUserInfoDictionary objectForKey:kBSUserUnsubscribedPush];
             }
             NSTimeInterval joinedAtTimeStamp = [[currentUserInfoDictionary objectForKey:kBSUserJoinedAt] doubleValue];
             

--- a/BlueShift-iOS-SDK/BlueshiftConstants.h
+++ b/BlueShift-iOS-SDK/BlueshiftConstants.h
@@ -23,6 +23,7 @@
 #define kDeviceID                               @"device_id"
 #define kApple                                  @"apple"
 #define kiOS                                    @"iOS"
+#define kBrowserPlatform                        @"browser_platform"
 
 //App Data
 #define kEnablePush                             @"enable_push"

--- a/BlueShift-iOS-SDK/BlueshiftConstants.h
+++ b/BlueShift-iOS-SDK/BlueshiftConstants.h
@@ -64,6 +64,7 @@
 #define openURLOptionsInAppType                 @"inAppType"
 #define openURLOptionsButtonIndex               @"clickedButtonIndex"
 #define openURLOptionsButtonText                @"clickedButtonText"
+#define openURLOptionsPushUserInfo              @"userInfo"
 
 //Core data entities
 #define kHttpRequestOperationEntity             @"HttpRequestOperationEntity"

--- a/BlueShift-iOS-SDK/BlueshiftEventAnalyticsHelper.h
+++ b/BlueShift-iOS-SDK/BlueshiftEventAnalyticsHelper.h
@@ -29,6 +29,11 @@ NS_ASSUME_NONNULL_BEGIN
 /// Check for nil and add the key value to the given dictionary
 + (void)addToDictionary:(NSMutableDictionary*)dictionary key:(NSString*)key value:(id)value;
 
+
+/// Returns true if string is not nil and not empty.
+/// @param string string to perform check
++ (BOOL)isNotNilAndNotEmpty:(NSString*)string;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/BlueShift-iOS-SDK/BlueshiftEventAnalyticsHelper.m
+++ b/BlueShift-iOS-SDK/BlueshiftEventAnalyticsHelper.m
@@ -165,8 +165,12 @@
 }
 
 +(BOOL)isNotNilAndNotEmpty:(NSString*)string {
-    if (string && ![string isEqualToString:@""]) {
-        return YES;
+    @try {
+        if (string && ![string isEqualToString:@""]) {
+            return YES;
+        }
+    } @catch (NSException *exception) {
+        [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
     }
     return NO;
 }

--- a/BlueShift-iOS-SDK/BlueshiftLog.m
+++ b/BlueShift-iOS-SDK/BlueshiftLog.m
@@ -49,7 +49,7 @@
 }
 
 + (void)logInfo:(NSString*)info withDetails: (id) details methodName:(NSString*)method{
-    if ([[BlueShift sharedInstance] config].debug) {
+    if ([BlueShift sharedInstance].config && [BlueShift sharedInstance].config.debug) {
         NSString* log = @"[Blueshift] info : ";
         @try {
             if (info) {
@@ -69,7 +69,7 @@
 }
 
 +(void)logAPICallInfo:(NSString*)info withDetails: (NSDictionary*) details statusCode:(NSInteger)statusCode {
-    if ([[BlueShift sharedInstance] config].debug) {
+    if ([BlueShift sharedInstance].config && [BlueShift sharedInstance].config.debug) {
         NSString* log = @"[Blueshift] API call info : ";
         @try {
         if (info) {

--- a/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotification.h
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotification.h
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign, readwrite) float height;
 @property (nonatomic, assign, readwrite) float width;;
 @property (nonatomic, assign, readwrite) BOOL enableBackgroundAction;
-@property (nonatomic, assign, readwrite) BOOL enableCloseButton;
+@property (nonatomic, assign, readwrite, nullable) NSNumber* enableCloseButton;
 @property (nonatomic, readwrite) BlueShiftInAppLayoutMargin *margin;
 @property (nonatomic, readwrite) BlueShiftInAppNotificationButton *closeButton;
 @property (nonatomic, assign, readwrite, nullable) NSNumber *backgroundDimAmount;

--- a/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotification.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotification.m
@@ -8,6 +8,7 @@
 #import "BlueShiftInAppNotification.h"
 #import "BlueShiftInAppNotificationHelper.h"
 #import "BlueShiftInAppNotificationConstant.h"
+#import "../BlueshiftLog.h"
 
 @implementation BlueShiftInAppNotificationButton
 
@@ -57,8 +58,8 @@
                     break;
             }
             
-        } @catch (NSException *e) {
-            
+        } @catch (NSException *exception) {
+            [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
         }
     }
     return self;
@@ -134,8 +135,8 @@
                     break;
             }
             
-        } @catch (NSException *e) {
-            
+        } @catch (NSException *exception) {
+            [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
         }
     }
     return self;
@@ -165,8 +166,8 @@
                 [marginDictionary objectForKey: kInAppNotificationModalLayoutMarginRightKey] != [NSNull null]) {
                 self.right = [[marginDictionary objectForKey: kInAppNotificationModalLayoutMarginRightKey] floatValue];
             }
-        } @catch (NSException *e) {
-            
+        } @catch (NSException *exception) {
+            [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
         }
     }
     
@@ -215,10 +216,6 @@
                     if ([templateStyleDictionary objectForKey: kInAppNotificationModalBackgroundImageKey] && [templateStyleDictionary objectForKey: kInAppNotificationModalBackgroundImageKey] != [NSNull null]) {
                         self.backgroundImage = (NSString *)[templateStyleDictionary objectForKey: kInAppNotificationModalBackgroundImageKey];
                     }
-                    if ([templateStyleDictionary objectForKey: kInAppNotificationModalEnableCloseButtonKey] &&
-                        [templateStyleDictionary objectForKey: kInAppNotificationModalEnableCloseButtonKey] != [NSNull null]){
-                        self.enableCloseButton = [[templateStyleDictionary objectForKey: kInAppNotificationModalEnableCloseButtonKey] boolValue];
-                    }
                     if ([templateStyleDictionary objectForKey: kInAppNotificationModalBackgroundRadiusKey] &&
                         [templateStyleDictionary objectForKey: kInAppNotificationModalBackgroundRadiusKey] != [NSNull null]) {
                         self.backgroundRadius = (NSNumber *)[templateStyleDictionary objectForKey: kInAppNotificationModalBackgroundRadiusKey];
@@ -226,6 +223,9 @@
                     if ([templateStyleDictionary objectForKey: kInAppNotificationModalCloseButtonKey] && [templateStyleDictionary objectForKey: kInAppNotificationModalCloseButtonKey] != [NSNull null]) {
                         NSDictionary *closeButtonPayload = [templateStyleDictionary objectForKey: kInAppNotificationModalCloseButtonKey];
                         self.closeButton =  [[BlueShiftInAppNotificationButton alloc] initFromDictionary: closeButtonPayload withType: inAppType];
+                        if ([closeButtonPayload objectForKey: kInAppNotificationModalEnableCloseButtonKey]){
+                            self.enableCloseButton = (NSNumber*)[closeButtonPayload objectForKey: kInAppNotificationModalEnableCloseButtonKey];
+                        }
                     }
                     if ([templateStyleDictionary objectForKey: kInAppNotificationModalBackgroundDimAmountKey] && [templateStyleDictionary objectForKey: kInAppNotificationModalBackgroundDimAmountKey] != [NSNull null]) {
                         self.backgroundDimAmount = (NSNumber *)[templateStyleDictionary objectForKey: kInAppNotificationModalBackgroundDimAmountKey];
@@ -241,8 +241,8 @@
                     break;
             }
             
-        } @catch (NSException *e) {
-            
+        } @catch (NSException *exception) {
+            [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
         }
     }
     return self;
@@ -384,8 +384,8 @@
                     break;
             }
             
-        } @catch (NSException *e) {
-            
+        } @catch (NSException *exception) {
+            [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
         }
     }
     return self;
@@ -446,8 +446,8 @@
                 
                 }
             }
-        } @catch (NSException *e) {
-            
+        } @catch (NSException *exception) {
+            [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
         }
     }
     return self;

--- a/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationConstant.h
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationConstant.h
@@ -54,7 +54,7 @@
 #define kInAppNotificationModalHeightKey                        @"height"
 #define kInAppNotificationModalBackgroundColorKey               @"background_color"
 #define kInAppNotificationModalBackgroundImageKey               @"background_image"
-#define kInAppNotificationModalEnableCloseButtonKey             @"enable_close_button"
+#define kInAppNotificationModalEnableCloseButtonKey             @"show"
 #define kInAppNotificationModalBackgroundActionKey              @"enable_background_action"
 #define kInAppNotificationModalCloseButtonKey                   @"close_button"
 #define kInAppNotificationModalBackgroundDimAmountKey           @"background_dim_amount"
@@ -110,7 +110,7 @@
 #define KInAppNotificationModalCloseButtonHeight                32.0
 
 #define kInAppNotificationDefaultWidth                          90.0
-#define kInAppNotificationDefaultHeight                         100.0
+#define kInAppNotificationDefaultHeight                         90.0
 
 #define kHTMLInAppNotificationMaximumWidthInPoints              470.0
 #define kHTMLInAppNotificationMinimumHeight                     25.0

--- a/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationHelper.h
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationHelper.h
@@ -48,6 +48,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// @warning In the sceneDelegate enabled apps, In order to access multiple windows to find the keyWindow, this function needs to be executed on the main thread
 + (UIWindow *)getApplicationKeyWindow;
 
+/// Returns MD5 hash for the given string
++ (NSString *)getMD5ForString:(NSString*)string;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationHelper.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationHelper.m
@@ -4,6 +4,7 @@
 //
 //  Created by shahas kp on 11/07/19.
 //
+#import <CommonCrypto/CommonDigest.h>
 
 #import "BlueShiftInAppNotificationHelper.h"
 #import "BlueShiftInAppNotificationConstant.h"
@@ -166,6 +167,20 @@ static NSDictionary *_inAppTypeDictionay;
         return YES;
     }
     return NO;
+}
+
++ (NSString *)getMD5ForString:(NSString*)string {
+    const char *cStr = [string UTF8String];
+    unsigned char result[CC_MD5_DIGEST_LENGTH];
+    CC_MD5( cStr, (CC_LONG)strlen(cStr), result );
+
+    return [NSString stringWithFormat:
+        @"%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X",
+        result[0], result[1], result[2], result[3],
+        result[4], result[5], result[6], result[7],
+        result[8], result[9], result[10], result[11],
+        result[12], result[13], result[14], result[15]
+    ];
 }
 
 @end

--- a/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationManager.h
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationManager.h
@@ -19,11 +19,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) double inAppNotificationTimeInterval;
 @property (nonatomic) NSString * _Nullable inAppNotificationDisplayOnPage;
 
-- (void) load;
-- (void) initializeInAppNotificationFromAPI:(NSMutableArray *)notificationArray handler:(void (^)(BOOL))handler;
+- (void)load;
+- (void)initializeInAppNotificationFromAPI:(NSMutableArray *)notificationArray handler:(void (^)(BOOL))handler;
 - (void)fetchInAppNotificationsFromDataStore: (BlueShiftInAppTriggerMode) triggerMode;
 - (void)fetchLastInAppMessageIDFromDB:(void (^)(BOOL, NSString *, NSString *))handler;
-- (void) deleteExpireInAppNotificationFromDataStore;
+- (void)deleteExpireInAppNotificationFromDataStore;
 - (void)markAsDisplayedForNotificationsViewedOnOtherDevice:(NSArray *)messageUUIDArray;
 
 @end

--- a/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationManager.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationManager.m
@@ -28,6 +28,7 @@
 
 @implementation BlueShiftInAppNotificationManager
 
+#pragma mark - Set up
 // init
 - (void)load {
     
@@ -35,26 +36,26 @@
 
     /* register for app background / foreground notification */
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(OnApplicationEnteringBackground:)
+                                             selector:@selector(onApplicationEnteringBackground:)
                                                  name:UIApplicationDidEnterBackgroundNotification
                                                object:nil];
     
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(OnApplicationEnteringForeground:)
+                                             selector:@selector(onApplicationEnteringForeground:)
                                                  name:UIApplicationWillEnterForegroundNotification
                                                object:nil];
     
      [self deleteExpireInAppNotificationFromDataStore];
 }
 
-- (void) OnApplicationEnteringBackground:(NSNotification *)notification {
+- (void)onApplicationEnteringBackground:(NSNotification *)notification {
     // stop the timer once app enters background.
     if ([[[BlueShift sharedInstance] config] inAppManualTriggerEnabled] == NO) {
         [self stopInAppMessageFetchTimer];
     }
 }
 
-- (void) OnApplicationEnteringForeground:(NSNotification *)notification {
+- (void)onApplicationEnteringForeground:(NSNotification *)notification {
     // start the timer once app enters foreground.
     if ([[[BlueShift sharedInstance] config] inAppManualTriggerEnabled] == NO && [[BlueShiftAppData currentAppData] getCurrentInAppNotificationStatus] == YES) {
         [self fetchNowAndUpcomingInAppMessageFromDB];
@@ -63,21 +64,33 @@
     }
 }
 
-- (void) initializeInAppNotificationFromAPI:(NSMutableArray *)notificationArray handler:(void (^)(BOOL))handler {
-    if (notificationArray !=nil && notificationArray.count > 0) {
-        for (int i = 0; i < notificationArray.count ; i++) {
-            [self addInAppNotificationToDataStore: [notificationArray objectAtIndex: i]];
-        }
-        
-        handler(YES);
-    } else {
-        handler(YES);
+- (void)startInAppMessageFetchTimer {
+    if (self.inAppMessageFetchTimer == nil) {
+        self.inAppMessageFetchTimer = [NSTimer scheduledTimerWithTimeInterval: [self inAppNotificationTimeInterval]
+                                                                    target:self
+                                                                  selector:@selector(fetchNowAndUpcomingInAppMessageFromDB)
+                                                                  userInfo:nil
+                                                                   repeats: YES];
+        [BlueshiftLog logInfo:@"Started InAppMessageFetchTimer" withDetails:nil methodName:nil];
     }
+}
+
+// Method to stop time gap b/w loading inAppNotification timer
+- (void)stopInAppMessageFetchTimer {
+    if (self.inAppMessageFetchTimer != nil) {
+        [self.inAppMessageFetchTimer invalidate];
+        self.inAppMessageFetchTimer = nil;
+        [BlueshiftLog logInfo:@"Stopped InAppMessageFetchTimer" withDetails:nil methodName:nil];
+    }
+}
+
+- (void)fetchNowAndUpcomingInAppMessageFromDB {
+    [self fetchInAppNotificationsFromDataStore: BlueShiftInAppTriggerNowAndUpComing];
 }
 
 //Remove the in-apps on receciving `in_app_mark_as_open` silent push which
 //are displayed on the other deivce for same user.
--(void)markAsDisplayedForNotificationsViewedOnOtherDevice:(NSArray *)messageUUIDArray {
+- (void)markAsDisplayedForNotificationsViewedOnOtherDevice:(NSArray *)messageUUIDArray {
     if (messageUUIDArray != nil && messageUUIDArray.count > 0) {
         for (int count = 0; count< messageUUIDArray.count; count++) {
             NSString *messageUUID = [messageUUIDArray objectAtIndex:count];
@@ -89,6 +102,64 @@
     }
 }
 
+#pragma mark - Insert, delete, update in-app notifications
+- (void)initializeInAppNotificationFromAPI:(NSMutableArray *)notificationArray handler:(void (^)(BOOL))handler {
+    if (notificationArray !=nil && notificationArray.count > 0) {
+        for (int i = 0; i < notificationArray.count ; i++) {
+            [self addInAppNotificationToDataStore: [notificationArray objectAtIndex: i]];
+        }
+    }
+    handler(YES);
+}
+
+- (void) addInAppNotificationToDataStore: (NSDictionary *) payload {
+    [self checkInAppNotificationExist: payload handler:^(BOOL status){
+        if (status == NO) {
+            if (nil == self.privateObjectContext) {
+                self.privateObjectContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSPrivateQueueConcurrencyType];
+            }
+            
+            BlueShiftAppDelegate *appDelegate = (BlueShiftAppDelegate *)[BlueShift sharedInstance].appDelegate;
+            NSManagedObjectContext *masterContext;
+            if (appDelegate) {
+                @try {
+                    masterContext = appDelegate.managedObjectContext;
+                }
+                @catch (NSException *exception) {
+                    [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
+                }
+            }
+            if(masterContext) {
+                NSEntityDescription *entity;
+                @try {
+                    entity = [NSEntityDescription entityForName: kInAppNotificationEntityNameKey inManagedObjectContext:masterContext];
+                }
+                @catch (NSException *exception) {
+                    [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
+                }
+                if(entity != nil) {
+                    InAppNotificationEntity *inAppNotificationEntity = [[InAppNotificationEntity alloc] initWithEntity:entity insertIntoManagedObjectContext: masterContext];
+                    
+                    if(inAppNotificationEntity != nil) {
+                        [inAppNotificationEntity insert:payload usingPrivateContext:self.privateObjectContext andMainContext: masterContext handler:^(BOOL status) {
+                            if(status) {
+                                [[BlueShift sharedInstance] trackInAppNotificationDeliveredWithParameter: payload canBacthThisEvent: NO];
+                                // invoke the inApp clicked callback method
+                                if ([self.inAppNotificationDelegate respondsToSelector:@selector(inAppNotificationDidDeliver:)]) {
+                                    [self.inAppNotificationDelegate inAppNotificationDidDeliver:payload];
+                                }
+                            }
+                        }];
+                    }
+                }
+            }
+        }
+    }];
+}
+
+/// Returns true if the In-App exists in the SDK database.
+/// @param payload  In-App notification payload
+/// @param handler completion handler
 - (void)checkInAppNotificationExist:(NSDictionary *)payload handler:(void (^)(BOOL))handler{
     BlueShiftAppDelegate *appDelegate = (BlueShiftAppDelegate *)[BlueShift sharedInstance].appDelegate;
     NSManagedObjectContext *masterContext;
@@ -116,11 +187,7 @@
             NSString *notificationID = [self getInAppMessageID: payload];
             if (notificationID !=nil && ![notificationID isEqualToString:@""]) {
                 [InAppNotificationEntity fetchNotificationByID:masterContext forNotificatioID: notificationID request: fetchRequest handler:^(BOOL status, NSArray *result){
-                    if (status) {
-                        handler(NO);
-                    } else {
-                        handler(YES);
-                    }
+                        handler(status);
                 }];
             }
         }
@@ -142,67 +209,7 @@
     return @"";
 }
 
-- (double)checkInAppNotificationExpired:(double)createdTime {
-    double currentTime =  [[NSDate date] timeIntervalSince1970];
-    NSDate *createdDate = [self convertMillisecondToDate: createdTime];
-    NSDate *currentDate = [self convertMillisecondToDate:currentTime];
-    
-    NSTimeInterval timeDifference = [currentDate timeIntervalSinceDate: createdDate];
-    return (timeDifference / (3600 * 24));
-}
-
-- (NSDate *)convertMillisecondToDate:(double)seconds {
-    return [NSDate dateWithTimeIntervalSince1970:seconds];
-}
-
-- (void) addInAppNotificationToDataStore: (NSDictionary *) payload {
-    [self checkInAppNotificationExist: payload handler:^(BOOL status){
-        if (status) {
-            if (nil == self.privateObjectContext) {
-                self.privateObjectContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSPrivateQueueConcurrencyType];
-            }
-            
-            BlueShiftAppDelegate *appDelegate = (BlueShiftAppDelegate *)[BlueShift sharedInstance].appDelegate;
-            NSManagedObjectContext *masterContext;
-            if (appDelegate) {
-                @try {
-                    masterContext = appDelegate.managedObjectContext;
-                }
-                @catch (NSException *exception) {
-                    [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
-                }
-            }
-            if(masterContext) {
-                NSEntityDescription *entity;
-                NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] init];
-                @try {
-                    entity = [NSEntityDescription entityForName: kInAppNotificationEntityNameKey inManagedObjectContext:masterContext];
-                    [fetchRequest setEntity:entity];
-                }
-                @catch (NSException *exception) {
-                    [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
-                }
-                if(entity != nil && fetchRequest.entity != nil) {
-                    InAppNotificationEntity *inAppNotificationEntity = [[InAppNotificationEntity alloc] initWithEntity:entity insertIntoManagedObjectContext: masterContext];
-                    
-                    if(inAppNotificationEntity != nil) {
-                        [inAppNotificationEntity insert:payload usingPrivateContext:self.privateObjectContext andMainContext: masterContext handler:^(BOOL status) {
-                            if(status) {
-                                [[BlueShift sharedInstance] trackInAppNotificationDeliveredWithParameter: payload canBacthThisEvent: NO];
-                                // invoke the inApp clicked callback method
-                                if ([self.inAppNotificationDelegate respondsToSelector:@selector(inAppNotificationDidDeliver:)]) {
-                                    [self.inAppNotificationDelegate inAppNotificationDidDeliver:payload];
-                                }
-                            }
-                        }];
-                    }
-                }
-            }
-        }
-    }];
-}
-
-- (void) deleteExpireInAppNotificationFromDataStore {
+- (void)deleteExpireInAppNotificationFromDataStore {
     BlueShiftAppDelegate *appDelegate = (BlueShiftAppDelegate *)[BlueShift sharedInstance].appDelegate;
     NSManagedObjectContext *masterContext;
     if (appDelegate) {
@@ -279,6 +286,19 @@
             }
         }];
     }
+}
+
+- (double)checkInAppNotificationExpired:(double)createdTime {
+    double currentTime =  [[NSDate date] timeIntervalSince1970];
+    NSDate *createdDate = [self convertMillisecondToDate: createdTime];
+    NSDate *currentDate = [self convertMillisecondToDate:currentTime];
+    
+    NSTimeInterval timeDifference = [currentDate timeIntervalSinceDate: createdDate];
+    return (timeDifference / (3600 * 24));
+}
+
+- (NSDate *)convertMillisecondToDate:(double)seconds {
+    return [NSDate dateWithTimeIntervalSince1970:seconds];
 }
 
 - (void)fetchLastInAppMessageIDFromDB:(void (^)(BOOL, NSString *, NSString *))handler {
@@ -400,7 +420,40 @@
     }
 }
 
+- (void)updateInAppNotification:(NSDictionary *)notificationPayload {
+    BlueShiftAppDelegate *appDelegate = (BlueShiftAppDelegate *)[BlueShift sharedInstance].appDelegate;
+    NSManagedObjectContext *masterContext;
+    if (appDelegate) {
+        @try {
+            masterContext = appDelegate.managedObjectContext;
+        }
+        @catch (NSException *exception) {
+            [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
+        }
+    }
+    if(masterContext) {
+        NSEntityDescription *entity;
+        NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] init];
+        @try {
+            entity = [NSEntityDescription entityForName: kInAppNotificationEntityNameKey inManagedObjectContext:masterContext];
+            [fetchRequest setEntity:entity];
+        }
+        @catch (NSException *exception) {
+            [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
+        }
+        
+        NSString *notificationID = [self getInAppMessageID: notificationPayload];
+        if (notificationID !=nil && ![notificationID isEqualToString:@""]) {
+        [InAppNotificationEntity updateInAppNotificationStatus: masterContext forNotificatioID: notificationID request: fetchRequest notificationStatus:@"Displayed" andAppDelegate: appDelegate handler:^(BOOL status){
+            if (status) {
+                [BlueshiftLog logInfo:@"Marked in-app message in DB as Displayed, messageId : " withDetails:notificationID methodName:nil];
+            }
+        }];
+        }
+    }
+}
 
+#pragma mark - Fetch in-app from the Datastore, filter and process it to display notification
 - (void)fetchInAppNotificationsFromDataStore: (BlueShiftInAppTriggerMode) triggerMode  {
     if([[BlueShiftAppData currentAppData] getCurrentInAppNotificationStatus] && [self inAppNotificationDisplayOnPage] && self.currentNotificationController == nil) {
     BlueShiftAppDelegate *appDelegate = (BlueShiftAppDelegate *)[BlueShift sharedInstance].appDelegate;
@@ -413,6 +466,9 @@
                 [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
             }
         }
+        if(masterContext == nil) {
+            return;
+        }
         [InAppNotificationEntity fetchAll:triggerMode forDisplayPage: [self inAppNotificationDisplayOnPage] context:masterContext withHandler:^(BOOL status, NSArray *results) {
             if (status) {
                 NSArray *sortedArray = [self sortedInAppNotification: results];
@@ -421,9 +477,15 @@
                     InAppNotificationEntity *entity = [filteredResults objectAtIndex:0];
                     [BlueshiftLog logInfo:@"Fetched one in-app message from DB to display message id - " withDetails:entity.id methodName:nil];
                     [self createNotificationFromDictionary: entity];
+                } else {
+                    [BlueshiftLog logInfo:@"There are no pending in-apps to display at this moment for page." withDetails:[self inAppNotificationDisplayOnPage] methodName:nil];
                 }
+            } else {
+                [BlueshiftLog logInfo:@"There are no pending in-apps to display for page." withDetails:[self inAppNotificationDisplayOnPage] methodName:nil];
             }
         }];
+    } else {
+        [BlueshiftLog logInfo:@"In-app fetch from DB skipped due to one of the below reasons." withDetails:@" 1. In-App notifications are not enabled, 2. Screen is not registered to receive in-apps. 3. Active or in-progress In-app notification detected." methodName:nil];
     }
 }
 
@@ -450,40 +512,6 @@
     
     return sortedArrayList;
 }
-
-- (void)updateInAppNotification:(NSDictionary *)notificationPayload {
-    BlueShiftAppDelegate *appDelegate = (BlueShiftAppDelegate *)[BlueShift sharedInstance].appDelegate;
-    NSManagedObjectContext *masterContext;
-    if (appDelegate) {
-        @try {
-            masterContext = appDelegate.managedObjectContext;
-        }
-        @catch (NSException *exception) {
-            [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
-        }
-    }
-    if(masterContext) {
-        NSEntityDescription *entity;
-        NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] init];
-        @try {
-            entity = [NSEntityDescription entityForName: kInAppNotificationEntityNameKey inManagedObjectContext:masterContext];
-            [fetchRequest setEntity:entity];
-        }
-        @catch (NSException *exception) {
-            [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
-        }
-        
-        NSString *notificationID = [self getInAppMessageID: notificationPayload];
-        if (notificationID !=nil && ![notificationID isEqualToString:@""]) {
-        [InAppNotificationEntity updateInAppNotificationStatus: masterContext forNotificatioID: notificationID request: fetchRequest notificationStatus:@"Displayed" andAppDelegate: appDelegate handler:^(BOOL status){
-            if (status) {   
-                [BlueshiftLog logInfo:@"Marked in-app message in DB as Displayed, messageId : " withDetails:notificationID methodName:nil];
-            }
-        }];
-        }
-    }
-}
-
 
 - (NSArray *) filterInAppNotificationResults: (NSArray*) results {
     
@@ -526,74 +554,48 @@
     return filteredResults;
 }
 
-- (void)startInAppMessageFetchTimer {
-    if (self.inAppMessageFetchTimer == nil) {
-        self.inAppMessageFetchTimer = [NSTimer scheduledTimerWithTimeInterval: [self inAppNotificationTimeInterval]
-                                                                    target:self
-                                                                  selector:@selector(fetchNowAndUpcomingInAppMessageFromDB)
-                                                                  userInfo:nil
-                                                                   repeats: YES];
-        [BlueshiftLog logInfo:@"Started InAppMessageFetchTimer" withDetails:nil methodName:nil];
-    }
+#pragma mark - Display in-app notification
+- (void)createNotificationFromDictionary:(InAppNotificationEntity *) inAppEntity {
+    BlueShiftInAppNotification *inAppNotification = [[BlueShiftInAppNotification alloc] initFromEntity:inAppEntity];
+    [BlueshiftLog logInfo:@"Created in-app object from dictionary, message Id: " withDetails:inAppEntity.id methodName:nil];
+    [self createInAppNotification: inAppNotification displayOnScreen:inAppEntity.displayOn];
 }
 
-// Method to stop time gap b/w loading inAppNotification timer
-- (void) stopInAppMessageFetchTimer {
-    if (self.inAppMessageFetchTimer != nil) {
-        [self.inAppMessageFetchTimer invalidate];
-        self.inAppMessageFetchTimer = nil;
-        [BlueshiftLog logInfo:@"Stopped InAppMessageFetchTimer" withDetails:nil methodName:nil];
-    }
-}
-
-- (void)fetchNowAndUpcomingInAppMessageFromDB {
-    [self fetchInAppNotificationsFromDataStore: BlueShiftInAppTriggerNowAndUpComing];
-}
-
-// Present ViewController
-- (void)presentInAppNotification:(BlueShiftNotificationViewController*)notificationController {
-    if ([self inAppNotificationDisplayOnPage] && self.currentNotificationController == nil) {
-        self.currentNotificationController = notificationController;
-        [notificationController show:YES];
-    }
-}
-
-
-- (void)createNotification:(BlueShiftInAppNotification*)notification {
-    BlueShiftNotificationViewController *notificationController;
-    NSString *errorString = nil;
-    
-    switch (notification.inAppType) {
-        case BlueShiftInAppTypeHTML:
-            notificationController = [[BlueShiftNotificationWebViewController alloc] initWithNotification:notification];
-            break;
-        case BlueShiftInAppTypeModal:
-            notificationController = [[BlueShiftNotificationModalViewController alloc] initWithNotification:notification];
-            break;
-        case BlueShiftNotificationSlideBanner:
-            notificationController = [[BlueShiftNotificationSlideBannerViewController alloc] initWithNotification:notification];
-            break;
-        case BlueShiftNotificationRating:
-            [self displayReviewController];
-            
-            /* delete this notification from coreData */
-            [self removeInAppNotificationFromDB: notification.objectID];
+- (void)createInAppNotification:(BlueShiftInAppNotification*)notification displayOnScreen:(NSString*)displayOnScreen {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (self.currentNotificationController != nil) {
+            [BlueshiftLog logInfo:@"Active In-app notification detected, skipped displaying current in-app." withDetails:nil methodName:nil];
             return;
-            
-            
-        default:
-            errorString = [NSString stringWithFormat:@"Unhandled notification type: %lu", (unsigned long)notification.inAppType];
+        }
+        
+        switch (notification.inAppType) {
+            case BlueShiftInAppTypeHTML:
+                [self processHTMLNotification:notification displayOnScreen:displayOnScreen];
+                break;
+                
+            case BlueShiftInAppTypeModal:
+                [self processModalNotification:notification displayOnScreen:displayOnScreen];
+                break;
+                
+            case BlueShiftNotificationSlideBanner:
+                [self processSlideInBannerNotification:notification displayOnScreen:displayOnScreen];
+                break;
+                
+            case BlueShiftNotificationRating:
+            {
+                [self displayReviewController];
+                [self removeInAppNotificationFromDB: notification.objectID];
+                return;;
+            }
+                
+            default:
+            {
+                NSString* errorString = [NSString stringWithFormat:@"Unhandled notification type: %lu", (unsigned long)notification.inAppType];
+                [BlueshiftLog logError:nil withDescription:errorString methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
+            }
             break;
-    }
-    if (notificationController) {
-        notificationController.delegate = self;
-        notificationController.inAppNotificationDelegate = self.inAppNotificationDelegate;
-        [notificationController setTouchesPassThroughWindow: notification.templateStyle.enableBackgroundAction];
-        [self presentInAppNotification:notificationController];
-    }
-    if (errorString) {
-        [BlueshiftLog logError:nil withDescription:errorString methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
-    }
+        }
+    });
 }
 
 - (void)displayReviewController {
@@ -602,15 +604,94 @@
     }
 }
 
-- (void)createNotificationFromDictionary:(InAppNotificationEntity *) inAppEntity {
-    BlueShiftInAppNotification *inAppNotification = [[BlueShiftInAppNotification alloc] initFromEntity:inAppEntity];
-    [BlueshiftLog logInfo:@"Created in-app message to display, message Id: " withDetails:inAppEntity.id methodName:nil];
-    [self createNotification: inAppNotification];
+-(void)processSlideInBannerNotification:(BlueShiftInAppNotification*)notification displayOnScreen:(NSString*)displayOnScreen {
+    [BlueshiftLog logInfo:@"Creating HTML in-app notification to display on screen name" withDetails:displayOnScreen methodName:nil];
+    BlueShiftNotificationViewController* notificationVC = [[BlueShiftNotificationSlideBannerViewController alloc] initWithNotification:notification];
+    notificationVC.displayOnScreen = displayOnScreen;
+    self.currentNotificationController = notificationVC;
+
+    BOOL isSlideInIconImagePresent = [notificationVC isSlideInIconImagePresent:notification];
+    BOOL isBackgroundImagePresent = [notificationVC isBackgroundImagePresentForNotification:notification];
+    if (isSlideInIconImagePresent || isBackgroundImagePresent) {
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            if(isSlideInIconImagePresent) {
+                [notificationVC loadAndCacheImageForURLString:notification.notificationContent.iconImage];
+            }
+            if (isBackgroundImagePresent) {
+                [notificationVC loadAndCacheImageForURLString:notification.templateStyle.backgroundImage];
+            }
+            [NSThread sleepForTimeInterval:1];
+            [self presentInAppViewController:notificationVC forNotification:notification];
+        });
+    } else {
+        [self presentInAppViewController:notificationVC forNotification:notification];
+    }
 }
 
+-(void)processModalNotification:(BlueShiftInAppNotification*)notification displayOnScreen:(NSString*)displayOnScreen {
+    [BlueshiftLog logInfo:@"Creating Modal in-app notification to display on screen name" withDetails:displayOnScreen methodName:nil];
+    BlueShiftNotificationViewController* notificationVC = [[BlueShiftNotificationModalViewController alloc] initWithNotification:notification];
+    notificationVC.displayOnScreen = displayOnScreen;
+    self.currentNotificationController = notificationVC;
+    BOOL isBackgroundImagePresent = [notificationVC isBackgroundImagePresentForNotification:notification];
+    BOOL isBannerImagePresent = [notificationVC isBannerImagePresentForNotification:notification];
+
+    if (isBackgroundImagePresent || isBannerImagePresent) {
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            if (isBackgroundImagePresent) {
+                [notificationVC loadAndCacheImageForURLString:notification.templateStyle.backgroundImage];
+            }
+            if (isBannerImagePresent) {
+                [notificationVC loadAndCacheImageForURLString:notification.notificationContent.banner];
+            }
+            [NSThread sleepForTimeInterval:1];
+            [self presentInAppViewController:notificationVC forNotification:notification];
+        });
+    } else {
+        [self presentInAppViewController:notificationVC forNotification:notification];
+    }
+}
+
+-(void)processHTMLNotification:(BlueShiftInAppNotification*)notification displayOnScreen:(NSString*)displayOnScreen {
+    [BlueshiftLog logInfo:@"Creating HTML in-app notification to display on screen name" withDetails:displayOnScreen methodName:nil];
+    BlueShiftNotificationViewController* notificationVC = [[BlueShiftNotificationWebViewController alloc] initWithNotification:notification];
+    notificationVC.displayOnScreen = displayOnScreen;
+    self.currentNotificationController = notificationVC;
+    
+    BlueShiftNotificationWebViewController *webViewController = (BlueShiftNotificationWebViewController*) notificationVC;
+    [webViewController setupWebView:^{
+        [self presentInAppViewController:notificationVC forNotification:notification];
+    }];
+}
+
+// Present ViewController
+- (void)presentInAppViewController:(BlueShiftNotificationViewController*)notificationController forNotification:(BlueShiftInAppNotification*)notification {
+    if (notificationController && [BlueshiftEventAnalyticsHelper isNotNilAndNotEmpty:notificationController.displayOnScreen]) {
+        if(self.inAppNotificationDisplayOnPage == nil || ![self.inAppNotificationDisplayOnPage isEqualToString:notificationController.displayOnScreen]) {
+            self.currentNotificationController = nil;
+            [BlueshiftLog logInfo:@"Skipping preseting in-app notification as current screen is different than in-app notification display on screen" withDetails:[self inAppNotificationDisplayOnPage] methodName:nil];
+            return;
+        }
+    }
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (notificationController && [self inAppNotificationDisplayOnPage]) {
+            [BlueshiftLog logInfo:@"Presenting in-app notification on the screen name" withDetails:[self inAppNotificationDisplayOnPage] methodName:nil];
+            notificationController.delegate = self;
+            notificationController.inAppNotificationDelegate = self.inAppNotificationDelegate;
+            [notificationController setTouchesPassThroughWindow: notification.templateStyle.enableBackgroundAction];
+            [notificationController show:YES];
+        } else {
+            self.currentNotificationController = nil;
+            [BlueshiftLog logInfo:@"Skipping preseting in-app notification as screen is not registered to receive in-app notification" withDetails:[self inAppNotificationDisplayOnPage] methodName:nil];
+        }
+    });
+}
+
+#pragma mark - In App events
 // Notification Click Callbacks
 -(void)inAppDidDismiss:(NSDictionary *)notificationPayload fromViewController:(BlueShiftNotificationViewController *)controller  {
     self.currentNotificationController = nil;
+    [[BlueShift sharedInstance].inAppImageDataCache removeAllObjects];
     if ([[[BlueShift sharedInstance] config] inAppManualTriggerEnabled] == NO) {
         [self startInAppMessageFetchTimer];
     }

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationModalViewController.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationModalViewController.m
@@ -473,7 +473,7 @@
             
             NSData* imageData = [self loadAndCacheImageForURLString:self.notification.templateStyle.backgroundImage];
             UIImage* image = [[UIImage alloc] initWithData:imageData];
-            [BlueshiftLog logInfo:@"Downloaded Image size is" withDetails:[NSString stringWithFormat:@"H:%f, W:%f",image.size.height,image.size.width] methodName:nil];
+            [BlueshiftLog logInfo:@"Image size is" withDetails:[NSString stringWithFormat:@"H:%f, W:%f",image.size.height,image.size.width] methodName:nil];
             
             // If auto height and auto width is set for image modal
             // and image resolution is less than the device height and width, use the image dimention.

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationModalViewController.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationModalViewController.m
@@ -439,9 +439,71 @@
     : xPadding;
 }
 
+- (CGSize)getAutoImageSizeForNotificationView {
+    float width = 0;
+    float height = 0;
+    
+    // Check if this modal is image modal
+    if ([self isBackgroundImagePresentForNotification:self.notification] && (self.notification.templateStyle.width < 0 || self.notification.templateStyle.height < 0)) {
+        
+        float templateWidth = 0;
+        if (self.notification.templateStyle && self.notification.templateStyle.width > 0) {
+            templateWidth = [BlueShiftInAppNotificationHelper convertPercentageWidthToPoints:self.notification.templateStyle.width forWindow:self.window];
+        }
+        float templateHeight = 0;
+        if(self.notification.templateStyle && self.notification.templateStyle.height > 0) {
+            templateHeight = [BlueShiftInAppNotificationHelper convertPercentageHeightToPoints: self.notification.templateStyle.height forWindow:self.window];
+        }
+        // Get max width & height in points which device can support
+        float maxWidthInPoints = templateWidth > 0 ? templateWidth : [BlueShiftInAppNotificationHelper convertPercentageWidthToPoints:kInAppNotificationDefaultWidth forWindow:self.window];
+        float maxHeightInPoints = templateHeight > 0 ? templateHeight : [BlueShiftInAppNotificationHelper convertPercentageHeightToPoints: kInAppNotificationDefaultHeight forWindow:self.window];
+        NSData* imageData = [self loadAndCacheImageForURLString:self.notification.templateStyle.backgroundImage];
+        UIImage* image = [[UIImage alloc] initWithData:imageData];
+        // If image resolution is less than the device height and width, use the image dimention.
+        if (image.size.width < maxWidthInPoints && image.size.height < maxHeightInPoints) {
+            width = image.size.width;
+            height = image.size.height;
+        } else {
+            // If image width/height is more than device width & height, modify the image height and width based on aspect ratio
+            float ratio = image.size.height/image.size.width;
+            width = maxWidthInPoints;
+            height = maxWidthInPoints * ratio;
+            if (height > maxHeightInPoints) {
+                width = maxHeightInPoints/ratio;
+                height = maxHeightInPoints;
+            }
+        }
+    }
+    return CGSizeMake(width, height);
+}
+
 - (CGRect)positionNotificationView {
-    float width = (self.notification.templateStyle && self.notification.templateStyle.width > 0) ? self.notification.templateStyle.width : self.notification.width;
-    float height = (self.notification.templateStyle && self.notification.templateStyle.height > 0) ? self.notification.templateStyle.height :[BlueShiftInAppNotificationHelper convertPointsHeightToPercentage: notificationView.frame.size.height forWindow:self.window];
+    BOOL isBackgroundImageModal = [self isBackgroundImagePresentForNotification:self.notification];
+    CGSize imageSize = CGSizeZero;
+    if (isBackgroundImageModal) {
+        imageSize = [self getAutoImageSizeForNotificationView];
+    }
+    float width = 0;
+    // If auto width, get the adjusted height using image width.
+    if (isBackgroundImageModal && imageSize.width > 0) {
+        width = [BlueShiftInAppNotificationHelper convertPointsWidthToPercentage: imageSize.width forWindow:self.window];
+    } else if (self.notification.templateStyle && self.notification.templateStyle.width > 0) {
+        width = self.notification.templateStyle.width;
+    } else {
+        // Default width
+        width = self.notification.width;
+    }
+    
+    float height = 0;
+    // If auto height, get the adjusted height from the image height
+    if (isBackgroundImageModal && imageSize.height > 0) {
+        height = [BlueShiftInAppNotificationHelper convertPointsHeightToPercentage: imageSize.height forWindow:self.window];
+    } else if(self.notification.templateStyle && self.notification.templateStyle.height > 0) {
+        height = self.notification.templateStyle.height;
+    } else {
+        // Default width
+        height = [BlueShiftInAppNotificationHelper convertPointsHeightToPercentage: notificationView.frame.size.height forWindow:self.window];
+    }
     
     float topMargin = 0.0;
     float bottomMargin = 0.0;

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationSlideBannerViewController.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationSlideBannerViewController.m
@@ -17,14 +17,12 @@
 
 @interface BlueShiftNotificationSlideBannerViewController ()<UIGestureRecognizerDelegate> {
     UIView *slideBannerView;
+    UIView *bottomSafeAreaView;
 }
 
 @property(nonatomic, assign) CGFloat initialHorizontalCenter;
 @property(nonatomic, assign) CGFloat initialTouchPositionX;
 @property(nonatomic, assign) CGFloat originalCenter;
-
-- (IBAction)onOkayButtonTapped:(id)sender;
-
 @end
 
 @implementation BlueShiftNotificationSlideBannerViewController
@@ -57,10 +55,8 @@
 }
 
 - (void)enableSingleTap {
-    UITapGestureRecognizer *singleFingerTap =
-    [[UITapGestureRecognizer alloc] initWithTarget:self
-                                              action:@selector(onOkayButtonTapped:)];
-    [slideBannerView addGestureRecognizer:singleFingerTap];
+    UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleSlideInTap)];
+    [slideBannerView addGestureRecognizer:tapGesture];
 }
 
 -(void)setTapGestureForView {
@@ -79,14 +75,17 @@
 }
 
 - (void)presentAnimationView {
+    [slideBannerView.layer addAnimation:[self getAnimationTransition] forKey:nil];
+    [self.view insertSubview:slideBannerView aboveSubview:self.view];
+}
+
+- (CATransition*)getAnimationTransition {
     CATransition *transition = [CATransition animation];
     transition.duration = 1.0;
     transition.type = kCATransitionPush;
     transition.subtype = kCATransitionFromLeft;
     [transition setTimingFunction:[CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseIn]];
-    [slideBannerView.layer addAnimation:transition forKey:nil];
-    
-    [self.view insertSubview:slideBannerView aboveSubview:self.view];
+    return transition;
 }
 
 - (void)createNotificationView {
@@ -161,10 +160,11 @@
             xPadding = iconLabel.frame.size.width;
         }
         
-        UIImageView *imageView;
+        UIView *iconView;
         if ([self isValidString: self.notification.notificationContent.iconImage]) {
-            imageView = [self createImageView];
-            xPadding = xPadding + imageView.frame.size.width;
+            // get empty default width height view for calculating the padding
+            iconView = [self createIconViewWithHeight:0];
+            xPadding = xPadding + iconView.frame.size.width;
         }
         
         UILabel *actionButtonLabel;
@@ -202,8 +202,8 @@
             if (descriptionLabelHeight < kSlideInInAppNotificationMinimumHeight) {
                 if (iconLabel.frame.size.height > 0) {
                     descriptionLabelHeight = iconLabel.frame.size.height;
-                } else if (imageView.frame.size.height > 0) {
-                    descriptionLabelHeight = imageView.frame.size.height;
+                } else if (iconView.frame.size.height > 0) {
+                    descriptionLabelHeight = iconView.frame.size.height;
                 } else {
                     descriptionLabelHeight = kSlideInInAppNotificationMinimumHeight;
                 }
@@ -220,48 +220,61 @@
             [self createNotificationView];
         }
         
-        imageView.frame = CGRectMake(0.0, 0.0, imageView.frame.size.width, slideBannerView.frame.size.height);
-        iconLabel.frame = CGRectMake(0.0, 0.0, iconLabel.frame.size.width, slideBannerView.frame.size.height);
-        
+        if ([self isValidString: self.notification.notificationContent.icon]) {
+            iconLabel.frame = CGRectMake(0.0, 0.0, iconLabel.frame.size.width, slideBannerView.frame.size.height);
+            [slideBannerView addSubview: iconLabel];
+        } else if ([self isValidString: self.notification.notificationContent.iconImage]) {
+            // Recreate the icon view after getting exact size of the banner
+            iconView = [self createIconViewWithHeight:slideBannerView.frame.size.height];
+            [slideBannerView addSubview: iconView];
+        }
+
         CGFloat actionXposition = slideBannerView.frame.size.width - actionButtonLabel.frame.size.width;
         actionButtonLabel.frame = CGRectMake(actionXposition, [self getCenterYPosition: actionButtonLabel.frame.size.height], actionButtonLabel.frame.size.width, actionButtonLabel.frame.size.height);
-        
-        [slideBannerView addSubview: iconLabel];
-        [slideBannerView addSubview: imageView];
         [slideBannerView addSubview: actionButtonLabel];
         [slideBannerView addSubview: descriptionLabel];
     }
 }
 
-- (UIImageView *)createImageView {
+- (UIView *)createIconViewWithHeight:(CGFloat)bannerHeight {
     BlueShiftInAppLayoutMargin *iconImagePadding = [self fetchNotificationIconImagePadding];
     CGFloat leftPadding = (iconImagePadding && iconImagePadding.left > 0) ? iconImagePadding.left : 0.0;
     CGFloat topPadding = (iconImagePadding && iconImagePadding.top > 0) ? iconImagePadding.top : 0.0;
     CGFloat rightPadding = (iconImagePadding && iconImagePadding.right > 0) ? iconImagePadding.right : 0.0;
     CGFloat bottomPadding= (iconImagePadding && iconImagePadding.bottom > 0) ? iconImagePadding.bottom : 0.0;
     
-    CGFloat imageViewWidth = kInAppNotificationModalIconWidth + (leftPadding + rightPadding);
-    CGFloat imageViewHeight = kInAppNotificationModalIconHeight+ (topPadding + bottomPadding);
-    CGRect cgRect = CGRectMake(0.0, 0.0, imageViewWidth, imageViewHeight);
+    CGFloat iconImageWidth = kInAppNotificationModalIconWidth - (leftPadding + rightPadding);
+    CGFloat iconImageHeight = kInAppNotificationModalIconHeight - (topPadding + bottomPadding);
     
-    UIImageView *imageView = [[UIImageView alloc] initWithFrame: cgRect];
+    CGFloat iconViewHeight = bannerHeight == 0 ? kInAppNotificationModalIconHeight : bannerHeight;
+    // Create a container view for the image
+    UIView* iconView = [[UIView alloc] initWithFrame: CGRectMake(0, 0, kInAppNotificationModalIconWidth, iconViewHeight)];
+    // Return the iconView if bannerHeight is 0.
+    if (bannerHeight == 0) {
+        return iconView;
+    }
+    
+    // Create imageView and set the image, padding and corner radius
+    UIImageView *imageView = [[UIImageView alloc] initWithFrame: CGRectMake(leftPadding, topPadding, iconImageWidth, iconImageHeight)];
+    // Set iconview center to show the image in the center when iconView height is more than the imageview height
+    imageView.center = iconView.center;
     if (self.notification.notificationContent.iconImage) {
        [self loadImageFromURL:self.notification.notificationContent.iconImage forImageView:imageView];
     }
-    
-    if (self.notification.contentStyle && self.notification.contentStyle.iconImageBackgroundColor != (id)[NSNull null] && self.notification.contentStyle.iconImageBackgroundColor.length > 0) {
-        NSString *backgroundColorCode = self.notification.contentStyle.iconImageBackgroundColor;
-        imageView.backgroundColor = [self colorWithHexString:backgroundColorCode];
-    }
-    
     CGFloat backgroundRadius = (self.notification.contentStyle && self.notification.contentStyle.iconImageBackgroundRadius && self.notification.contentStyle.iconImageBackgroundRadius.floatValue > 0) ? self.notification.contentStyle.iconImageBackgroundRadius.floatValue : 0.0;
-    
     imageView.layer.cornerRadius = backgroundRadius;
     imageView.clipsToBounds = YES;
     imageView.contentMode = UIViewContentModeScaleAspectFit;
-    imageView.autoresizingMask = UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin;
+
+    // Set background color to the iconView
+    if (self.notification.contentStyle && self.notification.contentStyle.iconImageBackgroundColor != (id)[NSNull null] && self.notification.contentStyle.iconImageBackgroundColor.length > 0) {
+        NSString *backgroundColorCode = self.notification.contentStyle.iconImageBackgroundColor;
+        iconView.backgroundColor = [self colorWithHexString:backgroundColorCode];
+    }
     
-    return imageView;
+    [iconView addSubview:imageView];
+    iconView.autoresizingMask = UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin;
+    return iconView;
 }
 
 - (UILabel *)createIconLabel:(CGFloat)xPosition {
@@ -351,18 +364,25 @@
     return actionButtonlabel;
 }
 
-- (void)createBottomSafeAreaView {
-    if([self getBottomSafeAreaHeight] > 0){
-        CGRect frame = slideBannerView.frame;
-        frame.size.height = [self getBottomSafeAreaHeight];
-        frame.origin.y = frame.origin.y;
-        UIView *bottomSafeAreaView = [[UIView alloc] initWithFrame: frame];
-        if (self.notification.templateStyle && self.notification.templateStyle.bottomSafeAreaColor && ![self.notification.templateStyle.bottomSafeAreaColor isEqualToString: @""]) {
+- (void)createBottomSafeAreaViewForFrame:(CGRect)slideInFrame {
+    if(slideInFrame.size.height > 0 && [self getBottomSafeAreaHeight] > 0 && self.notification.templateStyle) {
+        //Show safe area view only if bottom margin is zero and color is not empty/nil.
+        if (self.notification.templateStyle.margin.bottom == 0 && self.notification.templateStyle.bottomSafeAreaColor && ![self.notification.templateStyle.bottomSafeAreaColor isEqualToString: @""]) {
+            [bottomSafeAreaView removeFromSuperview];
+            CGRect frame = slideInFrame;
+            frame.size.height = [self getBottomSafeAreaHeight];
+            frame.origin.y = slideInFrame.origin.y + slideInFrame.size.height;
+            if (bottomSafeAreaView) {
+                bottomSafeAreaView.frame = frame;
+            } else {
+                bottomSafeAreaView = [[UIView alloc] initWithFrame: frame];
+                [bottomSafeAreaView.layer addAnimation:[self getAnimationTransition] forKey:nil];
+                [bottomSafeAreaView addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleSlideInTap)]];
+            }
             UIColor *backgroundColor = [self colorWithHexString: self.notification.templateStyle.bottomSafeAreaColor];
             [bottomSafeAreaView setBackgroundColor: backgroundColor];
+            [self.view addSubview: bottomSafeAreaView];
         }
-        
-        [self.view addSubview: bottomSafeAreaView];
     }
 }
 
@@ -385,7 +405,7 @@
     [self hideFromWindow:YES withDirection:UISwipeGestureRecognizerDirectionRight];
 }
 
-- (IBAction)onOkayButtonTapped:(id)sender {
+- (void)handleSlideInTap {
     if (self.notification && self.notification.notificationContent && self.notification.notificationContent.actions &&
         self.notification.notificationContent.actions.count > 0 &&
         self.notification.notificationContent.actions[0]) {
@@ -462,7 +482,7 @@
     } else if([position  isEqual: kInAppNotificationModalPositionBottomKey]) {
         frame.origin.y = screenSize.height - (size.height + bottomMargin);
         slideBannerView.autoresizingMask = slideBannerView.autoresizingMask | UIViewAutoresizingFlexibleTopMargin;
-//      [self createBottomSafeAreaView];
+        [self createBottomSafeAreaViewForFrame:frame];
     } else {
         frame.origin.y = (screenSize.height - size.height) / 2.0f;
     }

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationViewController.h
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationViewController.h
@@ -16,9 +16,9 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol BlueShiftNotificationDelegate <NSObject>
 @optional
 - (void)inAppDidDismiss:(NSDictionary *)notificationPayload fromViewController:(BlueShiftNotificationViewController*)controller;
-- (void)inAppActionDidTapped:(NSDictionary *)notificationActionButtonPayload fromViewController:(BlueShiftNotificationViewController *)
-controller;
+- (void)inAppActionDidTapped:(NSDictionary *)notificationActionButtonPayload fromViewController:(BlueShiftNotificationViewController *)controller;
 - (void)inAppDidShow:(NSDictionary *)notification fromViewController:(BlueShiftNotificationViewController*)controller;
+- (void)presentInAppViewController:(BlueShiftNotificationViewController*)notificationController forNotification:(BlueShiftInAppNotification*)notification;
 @end
 
 @interface BlueShiftNotificationViewController : UIViewController

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationViewController.h
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationViewController.h
@@ -28,6 +28,7 @@ controller;
 @property (nonatomic, assign) BOOL canTouchesPassThroughWindow;
 @property (nonatomic, weak) id <BlueShiftNotificationDelegate> delegate;
 @property (nonatomic, weak) id<BlueShiftInAppNotificationDelegate> inAppNotificationDelegate;
+@property (nonatomic, strong) NSString* _Nullable displayOnScreen;
 
 - (instancetype)initWithNotification:(BlueShiftInAppNotification *)notification;
 
@@ -61,6 +62,20 @@ controller;
 /// returns dictionary with in-app notification details to share to openURL method of appDelegate
 /// @param inAppbutton nullable in-app notification clicked button object
 - (NSDictionary *)getInAppOpenURLOptions:(BlueShiftInAppNotificationButton * _Nullable)inAppbutton;
+
+-(NSData*)loadAndCacheImageForURLString:(NSString*)urlString;
+
+/// Check if the notification has a valid background image present.
+/// @param notification notification object to perfor the check
+- (BOOL)isBackgroundImagePresentForNotification:(BlueShiftInAppNotification*)notification;
+
+/// Check if the slide in notification has in icon background image present.
+/// @param notification notification object to perfor the check
+- (BOOL)isSlideInIconImagePresent:(BlueShiftInAppNotification*)notification;
+
+/// Check if the notification has a valid banner image present.
+/// @param notification notification object to perfor the check
+- (BOOL)isBannerImagePresentForNotification:(BlueShiftInAppNotification*)notification;
 
 @end
 

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationViewController.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationViewController.m
@@ -140,8 +140,9 @@
     NSData *imageData = [[NSData alloc] init];
     @try {
         if([BlueshiftEventAnalyticsHelper isNotNilAndNotEmpty:urlString]) {
-            if([BlueShift sharedInstance].inAppImageDataCache && [[BlueShift sharedInstance].inAppImageDataCache objectForKey: urlString]) {
-                imageData = [[BlueShift sharedInstance].inAppImageDataCache objectForKey:urlString];
+            NSString *urlMD5Hash = [BlueShiftInAppNotificationHelper getMD5ForString: urlString];
+            if([BlueShift sharedInstance].inAppImageDataCache && [[BlueShift sharedInstance].inAppImageDataCache objectForKey: urlMD5Hash]) {
+                imageData = [[BlueShift sharedInstance].inAppImageDataCache objectForKey:urlMD5Hash];
                 [BlueshiftLog logInfo:@"Loading image from image cache for url" withDetails:urlString methodName:nil];
             } else {
                 NSURL *url = [NSURL URLWithString:urlString];
@@ -152,7 +153,7 @@
                         if ([BlueShift sharedInstance].inAppImageDataCache == nil) {
                             [BlueShift sharedInstance].inAppImageDataCache = [[NSCache alloc] init];
                         }
-                        [[BlueShift sharedInstance].inAppImageDataCache setObject:imageData forKey:urlString];
+                        [[BlueShift sharedInstance].inAppImageDataCache setObject:imageData forKey:urlMD5Hash];
                         [BlueshiftLog logInfo:@"Downloaded image successfully with size in KB" withDetails:[NSNumber numberWithFloat:(imageData.length/1024.0f)] methodName:nil];
                     }
                 }
@@ -258,8 +259,6 @@
         }
         if (backgroundColorCode != (id)[NSNull null] && backgroundColorCode.length > 0) {
             [button setBackgroundColor:[self colorWithHexString:backgroundColorCode]];
-        } else {
-            [button setBackgroundColor:UIColor.clearColor];
         }
     }
 }

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationViewController.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationViewController.m
@@ -16,7 +16,6 @@
 
 @interface BlueShiftNotificationViewController () {
     BlueShiftNotificationCloseButton *_closeButton;
-    NSMutableDictionary *cachedImageData;
 }
 @end
 
@@ -28,7 +27,6 @@
         notification.contentStyle = ([self isDarkThemeEnabled] && notification.contentStyleDark) ? notification.contentStyleDark : notification.contentStyle;
         notification.templateStyle = ([self isDarkThemeEnabled] && notification.templateStyleDark) ? notification.templateStyleDark : notification.templateStyle;
         _notification = notification;
-        cachedImageData = [[NSMutableDictionary alloc] init];
     }
     return self;
 }
@@ -105,13 +103,17 @@
 }
 
 - (UIColor *)colorWithHexString:(NSString *)str {
-    unsigned char r, g, b;
-    const char *cStr = [str cStringUsingEncoding:NSASCIIStringEncoding];
-    long x = strtol(cStr+1, NULL, 16);
-    b =  x & 0xFF;
-    g = (x >> 8) & 0xFF;
-    r = (x >> 16) & 0xFF;
-    return [UIColor colorWithRed:(float)r/255.0f green:(float)g/255.0f blue:(float)b/255.0f alpha:1];
+    if (str) {
+        unsigned char r, g, b;
+        const char *cStr = [str cStringUsingEncoding:NSASCIIStringEncoding];
+        long x = strtol(cStr+1, NULL, 16);
+        b =  x & 0xFF;
+        g = (x >> 8) & 0xFF;
+        r = (x >> 16) & 0xFF;
+        return [UIColor colorWithRed:(float)r/255.0f green:(float)g/255.0f blue:(float)b/255.0f alpha:1];
+    } else {
+        return [UIColor clearColor];
+    }
 }
 
 
@@ -124,8 +126,7 @@
 }
 
 - (void)setBackgroundImageFromURL:(UIView *)notificationView {
-    if (notificationView && self.notification.templateStyle && self.notification.templateStyle.backgroundImage &&
-    ![self.notification.templateStyle.backgroundImage isEqualToString:@""]) {
+    if (notificationView && [self isBackgroundImagePresentForNotification:self.notification]) {
         NSString *backgroundImageURL = self.notification.templateStyle.backgroundImage;
         UIImage *image = [[UIImage alloc] initWithData:[self loadAndCacheImageForURLString:backgroundImageURL]];
         UIImageView *imageView = [[UIImageView alloc] initWithImage:image];
@@ -137,13 +138,28 @@
 
 -(NSData*)loadAndCacheImageForURLString:(NSString*)urlString {
     NSData *imageData = [[NSData alloc] init];
-    if([cachedImageData valueForKey: urlString]) {
-        imageData = [cachedImageData valueForKey:urlString];
-    } else {
-        imageData = [[NSData alloc] initWithContentsOfURL: [NSURL URLWithString: urlString]];
-        if (imageData) {
-            [cachedImageData setObject:imageData forKey:urlString];
+    @try {
+        if([BlueshiftEventAnalyticsHelper isNotNilAndNotEmpty:urlString]) {
+            if([BlueShift sharedInstance].inAppImageDataCache && [[BlueShift sharedInstance].inAppImageDataCache objectForKey: urlString]) {
+                imageData = [[BlueShift sharedInstance].inAppImageDataCache objectForKey:urlString];
+                [BlueshiftLog logInfo:@"Loading image from image cache for url" withDetails:urlString methodName:nil];
+            } else {
+                NSURL *url = [NSURL URLWithString:urlString];
+                if (url) {
+                    [BlueshiftLog logInfo:@"Downloading image using url" withDetails:urlString methodName:nil];
+                    imageData = [[NSData alloc] initWithContentsOfURL:url];
+                    if (imageData) {
+                        if ([BlueShift sharedInstance].inAppImageDataCache == nil) {
+                            [BlueShift sharedInstance].inAppImageDataCache = [[NSCache alloc] init];
+                        }
+                        [[BlueShift sharedInstance].inAppImageDataCache setObject:imageData forKey:urlString];
+                        [BlueshiftLog logInfo:@"Downloaded image successfully with size in KB" withDetails:[NSNumber numberWithFloat:(imageData.length/1024.0f)] methodName:nil];
+                    }
+                }
+            }
         }
+    } @catch (NSException *exception) {
+        [BlueshiftLog logException:exception withDescription:nil methodName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
     }
     return imageData;
 }
@@ -174,14 +190,29 @@
     self.view.backgroundColor = [[UIColor blackColor] colorWithAlphaComponent: backgroundDimAmount];
 }
 
+- (BOOL)checkDefaultCloseButtonStatusForInApp {
+    if((self.notification.inAppType == BlueShiftInAppTypeModal && self.notification.notificationContent.actions.count == 0) || self.notification.inAppType == BlueShiftInAppTypeHTML) {
+        return YES;
+    }
+    return NO;
+}
+
+- (BOOL)shouldShowCloseButton {
+    if (self.notification.templateStyle.enableCloseButton) {
+        return [self.notification.templateStyle.enableCloseButton boolValue];
+    }
+    return [self checkDefaultCloseButtonStatusForInApp];
+}
+
 - (void)createCloseButton:(CGRect)frame {
-    BOOL showCloseButton = ((self.notification.inAppType == BlueShiftInAppTypeModal && self.notification.notificationContent.actions.count == 0) || self.notification.inAppType == BlueShiftInAppTypeHTML) ? YES : self.notification.templateStyle.enableCloseButton;
+    BOOL showCloseButton = [self shouldShowCloseButton];
+    CGFloat margin = 5;
     if (self.notification.templateStyle && showCloseButton) {
         if ( self.notification.templateStyle.closeButton
             && self.notification.templateStyle.closeButton.text
             && ![self.notification.templateStyle.closeButton.text isEqualToString:@""]) {
-            CGFloat xPosition = frame.origin.x + frame.size.width - KInAppNotificationModalCloseButtonWidth - 5;
-            CGRect cgRect = CGRectMake(xPosition, frame.origin.y + 5, KInAppNotificationModalCloseButtonWidth, KInAppNotificationModalCloseButtonHeight);
+            CGFloat xPosition = frame.origin.x + frame.size.width - KInAppNotificationModalCloseButtonWidth - margin;
+            CGRect cgRect = CGRectMake(xPosition, frame.origin.y + margin, KInAppNotificationModalCloseButtonWidth, KInAppNotificationModalCloseButtonHeight);
             UIButton *closeButtonLabel = [[UIButton alloc] initWithFrame:cgRect];
             BlueShiftInAppNotificationButton *closeButton = self.notification.templateStyle.closeButton;
             CGFloat closeButtonFontSize = (closeButton && closeButton.textSize && closeButton.textSize.floatValue > 0)
@@ -205,8 +236,8 @@
             [closeButtonLabel.titleLabel setTextAlignment: NSTextAlignmentCenter];
             [self.view addSubview: closeButtonLabel];
         } else {
-            CGFloat xPosition = frame.origin.x + frame.size.width - KInAppNotificationModalCloseButtonWidth;
-            CGRect cgRect = CGRectMake(xPosition, frame.origin.y, KInAppNotificationModalCloseButtonWidth, KInAppNotificationModalCloseButtonHeight);
+            CGFloat xPosition = frame.origin.x + frame.size.width - KInAppNotificationModalCloseButtonWidth - margin;
+            CGRect cgRect = CGRectMake(xPosition, frame.origin.y + margin, KInAppNotificationModalCloseButtonWidth, KInAppNotificationModalCloseButtonHeight);
             _closeButton = [BlueShiftNotificationCloseButton new];
             [_closeButton addTarget:self action:@selector(closeButtonDidTapped) forControlEvents:UIControlEventTouchUpInside];
             _closeButton.frame = cgRect;
@@ -227,6 +258,8 @@
         }
         if (backgroundColorCode != (id)[NSNull null] && backgroundColorCode.length > 0) {
             [button setBackgroundColor:[self colorWithHexString:backgroundColorCode]];
+        } else {
+            [button setBackgroundColor:UIColor.clearColor];
         }
     }
 }
@@ -462,6 +495,18 @@
     }
 
     return NO;
+}
+
+- (BOOL)isBackgroundImagePresentForNotification:(BlueShiftInAppNotification*)notification {
+    return (notification && notification.templateStyle && [BlueshiftEventAnalyticsHelper isNotNilAndNotEmpty:notification.templateStyle.backgroundImage]);
+}
+
+- (BOOL)isBannerImagePresentForNotification:(BlueShiftInAppNotification*)notification {
+    return (notification && notification.notificationContent && [BlueshiftEventAnalyticsHelper isNotNilAndNotEmpty:notification.notificationContent.banner]);
+}
+
+- (BOOL)isSlideInIconImagePresent:(BlueShiftInAppNotification*)notification {
+    return (notification && notification.notificationContent && [BlueshiftEventAnalyticsHelper isNotNilAndNotEmpty:notification.notificationContent.iconImage]);
 }
 
 @end

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationWebViewController.h
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationWebViewController.h
@@ -11,7 +11,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface BlueShiftNotificationWebViewController : BlueShiftNotificationViewController
-- (void)setupWebView:(void (^)(void))block;
+- (void)setupWebView;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationWebViewController.h
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationWebViewController.h
@@ -11,7 +11,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface BlueShiftNotificationWebViewController : BlueShiftNotificationViewController
-
+- (void)setupWebView:(void (^)(void))block;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationWebViewController.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationWebViewController.m
@@ -18,6 +18,7 @@ API_AVAILABLE(ios(8.0))
     WKWebView *webView;
     BOOL isAutoHeight;
     BOOL isAutoWidth;
+    void (^ didLoadWebView)(void);
 }
 
 @property(nonatomic, retain) UIPanGestureRecognizer *panGesture;
@@ -39,9 +40,14 @@ API_AVAILABLE(ios(8.0))
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+}
+
+- (void)setupWebView:(void (^)(void))block {
+    didLoadWebView = block;
     [self setAutomaticScale];
     [self configureBackground];
     [self presentWebViewNotification];
+    [self initialiseWebView];
 }
 
 - (void) viewWillLayoutSubviews {
@@ -224,7 +230,7 @@ API_AVAILABLE(ios(8.0))
     
     NSString* position = (self.notification.templateStyle && self.notification.templateStyle.position) ? self.notification.templateStyle.position : self.notification.position;
     
-    int extra = (int) (self.notification.templateStyle && self.notification.templateStyle.enableCloseButton ? ( KInAppNotificationModalCloseButtonWidth/ 2.0f) : 0.0f);
+    int extra = (int) (self.notification.templateStyle && [self.notification.templateStyle.enableCloseButton boolValue] ? ( KInAppNotificationModalCloseButtonWidth/ 2.0f) : 0.0f);
     
     if([position  isEqual: kInAppNotificationModalPositionTopKey]) {
         frame.origin.x = (screenSize.width - size.width) / 2.0f;
@@ -285,7 +291,10 @@ API_AVAILABLE(ios(8.0))
 - (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation {
     [webView evaluateJavaScript:@"document.readyState" completionHandler:^(id _Nullable complete, NSError * _Nullable error) {
         if (complete) {
-            [self resizeWebViewAsPerContent:webView];
+            self->didLoadWebView();
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self resizeWebViewAsPerContent:webView];
+            });
         }
     }];
 }

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationWebViewController.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationWebViewController.m
@@ -18,7 +18,6 @@ API_AVAILABLE(ios(8.0))
     WKWebView *webView;
     BOOL isAutoHeight;
     BOOL isAutoWidth;
-    void (^ didLoadWebView)(void);
 }
 
 @property(nonatomic, retain) UIPanGestureRecognizer *panGesture;
@@ -42,8 +41,7 @@ API_AVAILABLE(ios(8.0))
     [super viewDidLoad];
 }
 
-- (void)setupWebView:(void (^)(void))block {
-    didLoadWebView = block;
+- (void)setupWebView {
     [self setAutomaticScale];
     [self configureBackground];
     [self presentWebViewNotification];
@@ -293,7 +291,9 @@ API_AVAILABLE(ios(8.0))
         if (complete) {
             [BlueshiftLog logInfo:@"Webview loaded the content successfully." withDetails:nil methodName:nil];
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 1*NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-                self->didLoadWebView();
+                if ([self delegate] && [[self delegate] respondsToSelector:@selector(presentInAppViewController:forNotification:)]) {
+                    [[self delegate] presentInAppViewController:self forNotification:self.notification];
+                }
                 [self resizeWebViewAsPerContent:webView];
             });
         }

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationWebViewController.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationWebViewController.m
@@ -291,8 +291,9 @@ API_AVAILABLE(ios(8.0))
 - (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation {
     [webView evaluateJavaScript:@"document.readyState" completionHandler:^(id _Nullable complete, NSError * _Nullable error) {
         if (complete) {
-            self->didLoadWebView();
-            dispatch_async(dispatch_get_main_queue(), ^{
+            [BlueshiftLog logInfo:@"Webview loaded the content successfully." withDetails:nil methodName:nil];
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 1*NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+                self->didLoadWebView();
                 [self resizeWebViewAsPerContent:webView];
             });
         }
@@ -305,6 +306,7 @@ API_AVAILABLE(ios(8.0))
 
 //resize webview as per content height & width when all the content/media is loaded
 - (void)resizeWebViewAsPerContent:(WKWebView *)webView  {
+    [BlueshiftLog logInfo:@"Resizing the in-app webview size based on the loaded content." withDetails:nil methodName:nil];
     [webView evaluateJavaScript:@"document.body.scrollHeight" completionHandler:^(id _Nullable height, NSError * _Nullable error) {
         [webView evaluateJavaScript:@"document.body.scrollWidth" completionHandler:^(id _Nullable width, NSError * _Nullable error) {
             dispatch_async(dispatch_get_main_queue(), ^{

--- a/BlueShift-iOS-SDK/NetworkReachability.m
+++ b/BlueShift-iOS-SDK/NetworkReachability.m
@@ -467,8 +467,8 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
 
 - (NSString *) description
 {
-    NSString *description = [NSString stringWithFormat:@"<%@: %#x (%@)>",
-                             NSStringFromClass([self class]), (unsigned int) self, [self currentReachabilityFlags]];
+    NSString *description = [NSString stringWithFormat:@"<%@: %#lx (%@)>",
+                             NSStringFromClass([self class]), (long int) self, [self currentReachabilityFlags]];
     return description;
 }
 


### PR DESCRIPTION
Download and cache images for in-app and show
Download the html content, load it and show in-app
Added fix for slidein inapp bottom safearea view
Show close button based on API response value else show it with default setting
Added icon radius to slide in icon
Added icon padding to slide in icon
Added auto height - auto width support for modal background image
Added backward compatibility for image modals
Pass push notification userinfo to the open url method
Rearranged the BlueshiftINAppNotificationManager methods
Added "browser_platform" in the tracking API
Added dedupe for push click processing
Added fix to handle silent push notifications to avoid firing click event
Fixed unsubscribed handling
Added md5 hash for image caching as key
Dispatch queue optimization for the in-app display and push delivered event
Fixed warning for the reachability class
Added logs
