### PR TITLE
Feature/coresdk actionable push

### DIFF
--- a/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
+++ b/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
@@ -415,33 +415,44 @@ static NSManagedObjectContext * _Nullable batchEventManagedObjectContext;
         }
         
         if (![BlueshiftEventAnalyticsHelper isCarouselPushNotificationPayload: userInfo]) {
-            [self setupPushNotificationDeeplink: userInfo];
+            [self setupPushNotificationDeeplink: userInfo actionIdentifier:nil];
         }
     }
 }
 
-- (void)setupPushNotificationDeeplink:(NSDictionary *)userInfo {
-    // invoke the push clicked callback method
-    if ([[[BlueShift sharedInstance].config blueShiftPushDelegate] respondsToSelector:@selector(pushNotificationDidClick:)]) {
-        [[[BlueShift sharedInstance].config blueShiftPushDelegate] pushNotificationDidClick:userInfo];
-    }
-
-    lastProcessedPushNotificationUUID = [userInfo valueForKey:kInAppNotificationModalMessageUDIDKey];
-    
-    [self trackAppOpenWithParameters:userInfo];
-
-    if (userInfo != nil && ([userInfo objectForKey: kPushNotificationDeepLinkURLKey] || [userInfo objectForKey: kNotificationURLElementKey])) {
-        NSURL *deepLinkURL = [NSURL URLWithString: [userInfo objectForKey: kPushNotificationDeepLinkURLKey]];
-        if (!deepLinkURL) {
-            deepLinkURL = [NSURL URLWithString: [userInfo objectForKey: kNotificationURLElementKey]];
+- (void)setupPushNotificationDeeplink:(NSDictionary *)userInfo actionIdentifier:(NSString* _Nullable)identifier {
+    @try {
+        // invoke the push clicked callback method
+        if ([userInfo[kNotificationTypeIdentifierKey] isEqualToString:kNotificationTypeActionable] && [[[BlueShift sharedInstance].config blueShiftPushDelegate] respondsToSelector:@selector(pushNotificationDidClick:forActionIdentifier:)]) {
+            [[[BlueShift sharedInstance].config blueShiftPushDelegate] pushNotificationDidClick:userInfo forActionIdentifier:identifier];
+        } else if ([[[BlueShift sharedInstance].config blueShiftPushDelegate] respondsToSelector:@selector(pushNotificationDidClick:)]) {
+            [[[BlueShift sharedInstance].config blueShiftPushDelegate] pushNotificationDidClick:userInfo];
         }
-        if ([self.mainAppDelegate respondsToSelector:@selector(application:openURL:options:)]) {
-            if (@available(iOS 9.0, *)) {
-                NSDictionary *pushOptions = @{openURLOptionsSource:openURLOptionsBlueshift,openURLOptionsChannel:openURLOptionsPush,openURLOptionsPushUserInfo:userInfo};
-                [self.mainAppDelegate application:[UIApplication sharedApplication] openURL: deepLinkURL options:pushOptions];
-                [BlueshiftLog logInfo:[NSString stringWithFormat:@"%@ %@",@"Delivered push notification deeplink to AppDelegate openURL method, Deep link - ", [deepLinkURL absoluteString]] withDetails: pushOptions methodName:nil];
+        
+        lastProcessedPushNotificationUUID = [userInfo valueForKey:kInAppNotificationModalMessageUDIDKey];
+        
+        [self trackAppOpenWithParameters:userInfo];
+        
+        if (userInfo != nil && ([userInfo objectForKey: kPushNotificationDeepLinkURLKey] || [userInfo objectForKey: kNotificationURLElementKey])) {
+            NSURL *deepLinkURL = [NSURL URLWithString: [userInfo objectForKey: kPushNotificationDeepLinkURLKey]];
+            if (!deepLinkURL) {
+                deepLinkURL = [NSURL URLWithString: [userInfo objectForKey: kNotificationURLElementKey]];
+            }
+            if ([self.mainAppDelegate respondsToSelector:@selector(application:openURL:options:)]) {
+                if (@available(iOS 9.0, *)) {
+                    NSMutableDictionary *pushOptions = [@{openURLOptionsSource:openURLOptionsBlueshift,
+                                                          openURLOptionsChannel:openURLOptionsPush,
+                                                          openURLOptionsPushUserInfo:userInfo} mutableCopy];
+                    if(identifier) {
+                        [pushOptions setValue:identifier forKey:openURLOptionsPushActionIdentifier];
+                    }
+                    [self.mainAppDelegate application:[UIApplication sharedApplication] openURL: deepLinkURL options:pushOptions];
+                    [BlueshiftLog logInfo:[NSString stringWithFormat:@"%@ %@",@"Delivered push notification deeplink to AppDelegate openURL method, Deep link - ", [deepLinkURL absoluteString]] withDetails: pushOptions methodName:nil];
+                }
             }
         }
+    } @catch (NSException *exception) {
+        [BlueshiftLog logException:exception withDescription:nil methodName:nil];
     }
 }
 
@@ -519,7 +530,7 @@ static NSManagedObjectContext * _Nullable batchEventManagedObjectContext;
             }
             
             if (![BlueshiftEventAnalyticsHelper isCarouselPushNotificationPayload: userInfo]) {
-                [self setupPushNotificationDeeplink: userInfo];
+                [self setupPushNotificationDeeplink: userInfo actionIdentifier:nil];
             }
         }
     }
@@ -685,11 +696,11 @@ static NSManagedObjectContext * _Nullable batchEventManagedObjectContext;
                 }
             }
             
-            [self setupPushNotificationDeeplink: pushDetails];
+            [self setupPushNotificationDeeplink: pushDetails actionIdentifier:nil];
             return;
         } else {
             
-            [self setupPushNotificationDeeplink: pushDetailsDictionary];
+            [self setupPushNotificationDeeplink: pushDetailsDictionary actionIdentifier:nil];
         }
     } else {
         [BlueshiftLog logInfo:@"Unable to process the deeplink as AppGroupId is not set in the Blueshift SDK initialization." withDetails:nil methodName:nil];
@@ -873,7 +884,9 @@ static NSManagedObjectContext * _Nullable batchEventManagedObjectContext;
     NSDictionary *pushDetailsDictionary = nil;
     pushDetailsDictionary = notification;
     self.userInfo = notification;
-    if ([identifier isEqualToString: kNotificationActionBuyIdentifier]) {
+    if ([notification[kNotificationTypeIdentifierKey] isEqualToString:kNotificationTypeActionable]) {
+        notification = [self handleCustomActionablePushNotification:notification forActionIdentifier:identifier];
+    } else if ([identifier isEqualToString: kNotificationActionBuyIdentifier]) {
         [self handleActionForBuyUsingPushDetailsDictionary:pushDetailsDictionary];
     } else if ([identifier isEqualToString: kNotificationActionViewIdentifier]) {
         [self handleActionForViewUsingPushDetailsDictionary:pushDetailsDictionary];
@@ -881,8 +894,7 @@ static NSManagedObjectContext * _Nullable batchEventManagedObjectContext;
         [self handleActionForOpenCartUsingPushDetailsDictionary:pushDetailsDictionary];
     } else if([identifier isEqualToString:kNotificationCarouselGotoappIdentifier]) {
         [self handleActionForCustomPageForIdentifier:kNotificationCarouselGotoappIdentifier UsingPushDetailsDictionary:pushDetailsDictionary];
-    }
-    else {
+    } else {
         // If any action other than the predefined action is selected ...
         // We allow user to implement a custom method which we will provide the neccessary details to the user which includes action identifier and push details ...
         
@@ -894,7 +906,7 @@ static NSManagedObjectContext * _Nullable batchEventManagedObjectContext;
         }
     }
     
-    [self setupPushNotificationDeeplink: notification];
+    [self setupPushNotificationDeeplink:notification actionIdentifier:identifier];
     
     // Must be called when finished
     completionHandler();
@@ -904,6 +916,24 @@ static NSManagedObjectContext * _Nullable batchEventManagedObjectContext;
   completionHandler: (void (^)(void)) completionHandler {
     
     [self handleActionWithIdentifier:identifier forRemoteNotification:notification completionHandler:completionHandler];
+}
+
+- (NSDictionary*)handleCustomActionablePushNotification:(NSDictionary *)notification forActionIdentifier:(NSString *)identifier {
+    NSArray *actions = (NSArray*)notification[kNotificationActions];
+    NSMutableDictionary *mutableNotification = [notification mutableCopy];
+    if (actions) {
+        NSString *deepLink = @"";
+        for (NSDictionary* action in actions) {
+            if ([action[kNotificationActionIdentifier] isEqualToString: identifier]) {
+                deepLink = action[kPushNotificationDeepLinkURLKey];
+                break;
+            }
+        }
+        [mutableNotification setValue:deepLink forKey:kNotificationURLElementKey];
+        NSDictionary *pushTrackParameterDictionary = [BlueshiftEventAnalyticsHelper pushTrackParameterDictionaryForPushDetailsDictionary:notification];
+        [self trackPushClickedWithParameters:pushTrackParameterDictionary];
+    }
+    return mutableNotification;
 }
 
 #pragma mark - Application lifecyle events

--- a/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
+++ b/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
@@ -922,14 +922,16 @@ static NSManagedObjectContext * _Nullable batchEventManagedObjectContext;
     NSArray *actions = (NSArray*)notification[kNotificationActions];
     NSMutableDictionary *mutableNotification = [notification mutableCopy];
     if (actions) {
-        NSString *deepLink = @"";
+        NSString *deepLink = nil;
         for (NSDictionary* action in actions) {
             if ([action[kNotificationActionIdentifier] isEqualToString: identifier]) {
                 deepLink = action[kPushNotificationDeepLinkURLKey];
                 break;
             }
         }
-        [mutableNotification setValue:deepLink forKey:kNotificationURLElementKey];
+        if (deepLink) {
+            [mutableNotification setValue:deepLink forKey:kNotificationURLElementKey];
+        }
         NSDictionary *pushTrackParameterDictionary = [BlueshiftEventAnalyticsHelper pushTrackParameterDictionaryForPushDetailsDictionary:notification];
         [self trackPushClickedWithParameters:pushTrackParameterDictionary];
     }

--- a/BlueShift-iOS-SDK/BlueShiftConfig.h
+++ b/BlueShift-iOS-SDK/BlueShiftConfig.h
@@ -21,9 +21,9 @@
 @property NSString * _Nonnull apiKey;
 @property NSDictionary * _Nonnull applicationLaunchOptions;
 
-@property NSURL * _Nullable productPageURL;
-@property NSURL * _Nullable cartPageURL;
-@property NSURL * _Nullable offerPageURL;
+@property NSURL * _Nullable productPageURL DEPRECATED_MSG_ATTRIBUTE("productPageURL deeplinking is deprecated and will be removed in future. Use push notification deep links instead.");
+@property NSURL * _Nullable cartPageURL DEPRECATED_MSG_ATTRIBUTE("cartPageURL deeplinking is deprecated and will be removed in future. Use push notification deep links instead.");
+@property NSURL * _Nullable offerPageURL DEPRECATED_MSG_ATTRIBUTE("offerPageURL deeplinking is deprecated and will be removed in future. Use push notification deep links instead.");
 
 /// Set this property to false in order to stop SDK from registering for silent(background) push notifications.
 /// @discussion SDK registers for silent push notifications in order to receive the in-app notifications when user has not asked for push permission

--- a/BlueShift-iOS-SDK/BlueShiftNotificationConstants.h
+++ b/BlueShift-iOS-SDK/BlueShiftNotificationConstants.h
@@ -17,6 +17,9 @@
 #define kNotificationCarouselElementIdentifierKey                       @"carousel_elements"
 #define kNotificationBodyKey                                            @"body"
 #define kNotificationTitleKey                                           @"title"
+#define kNotificationTypeActionable                                     @"actionable_notification"
+#define kNotificationActions                                            @"actions"
+#define kNotificationActionIdentifier                                   @"identifier"
 
 #define kNotificationSchedulerKey                                       @"notification_scheduler"
 #define kNotificationTimestampToDisplayKey                              @"timestamp_to_display"

--- a/BlueShift-iOS-SDK/BlueShiftPushDelegate.h
+++ b/BlueShift-iOS-SDK/BlueShiftPushDelegate.h
@@ -7,23 +7,34 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol BlueShiftPushDelegate <NSObject>
 
 @optional
-- (void) buyPushActionWithDetails:(NSDictionary *)details;
-- (void) viewPushActionWithDetails:(NSDictionary *)details;
-- (void) openCartPushActionWithDetails:(NSDictionary *)details;
-- (void) handlePushActionForIdentifier:(NSString *)identifier withDetails:(NSDictionary *)details;
+- (void)buyPushActionWithDetails:(NSDictionary *)details DEPRECATED_MSG_ATTRIBUTE("Buy category is deprecated and will be removed in future. Use custom actionable push notifications instead.");
+- (void)viewPushActionWithDetails:(NSDictionary *)details DEPRECATED_MSG_ATTRIBUTE("View category is deprecated and will be removed in future. Use custom actionable push notifications instead.");
+- (void)openCartPushActionWithDetails:(NSDictionary *)details DEPRECATED_MSG_ATTRIBUTE("Open cart category is deprecated and will be removed in future. Use custom actionable push notifications instead.");
+- (void)handlePushActionForIdentifier:(NSString *)identifier withDetails:(NSDictionary *)details DEPRECATED_MSG_ATTRIBUTE("This method is deprecated and will be removed in future. Use `pushNotificationDidClick:(NSDictionary *)payload forActionIdentifier:(NSString *)identifier` method instead.");
 
-- (void) buyCategoryPushClickedWithDetails:(NSDictionary *)details;
-- (void) cartViewCategoryPushClickedWithDetails:(NSDictionary *)details;
-- (void) promotionCategoryPushClickedWithDetails:(NSDictionary *)details;
-- (void) handleCustomCategory:(NSString *)categroyName clickedWithDetails:(NSDictionary *)details;
-- (void) handleCarouselPushForCategory:(NSString *)categoryName clickedWithIndex:(NSInteger)index withDetails:(NSDictionary *)details;
+- (void)buyCategoryPushClickedWithDetails:(NSDictionary *)details DEPRECATED_MSG_ATTRIBUTE("Buy category is deprecated and will be removed in future. Use custom actionable push notifications instead.");
+- (void)cartViewCategoryPushClickedWithDetails:(NSDictionary *)details DEPRECATED_MSG_ATTRIBUTE("Cart view category is deprecated and will be removed in future. Use custom actionable push notifications instead.");
+- (void)promotionCategoryPushClickedWithDetails:(NSDictionary *)details DEPRECATED_MSG_ATTRIBUTE("Promotion category is deprecated and will be removed in future. Use `pushNotificationDidClick:(NSDictionary *)payload` method instead.");
+- (void)handleCustomCategory:(NSString *)categroyName clickedWithDetails:(NSDictionary *)details DEPRECATED_MSG_ATTRIBUTE("This method is deprecated and will be removed in future. Use `pushNotificationDidClick:(NSDictionary *)payload` method instead.");
 
+- (void)handleCarouselPushForCategory:(NSString *)categoryName clickedWithIndex:(NSInteger)index withDetails:(NSDictionary *)details;
+
+
+/// This is a SDK hook/callback for the click event of custom action button for push notification .
+/// @param payload push notification payload
+/// @param identifier custom action button identifier.
+/// @note The additional details related to clicked action can be found in the payload's `actions` array using the action identifier.
+- (void)pushNotificationDidClick:(NSDictionary * _Nullable)payload forActionIdentifier:(NSString * _Nullable)identifier;
 
 /// This is a SDK hook/callback for the push notification click event.
 /// @param payload push notification payload
 /// @discussion When SDK processes a push notification click/action, it invokes this callback method and shares the push notification payload.
-- (void) pushNotificationDidClick:(NSDictionary *)payload;
+- (void)pushNotificationDidClick:(NSDictionary * _Nullable)payload;
 @end 
+
+NS_ASSUME_NONNULL_END

--- a/BlueShift-iOS-SDK/BlueshiftConstants.h
+++ b/BlueShift-iOS-SDK/BlueshiftConstants.h
@@ -72,6 +72,7 @@
 #define openURLOptionsButtonIndex               @"clickedButtonIndex"
 #define openURLOptionsButtonText                @"clickedButtonText"
 #define openURLOptionsPushUserInfo              @"userInfo"
+#define openURLOptionsPushActionIdentifier      @"actionIdentifier"
 
 //Core data entities
 #define kHttpRequestOperationEntity             @"HttpRequestOperationEntity"

--- a/BlueShift-iOS-SDK/BlueshiftEventAnalyticsHelper.m
+++ b/BlueShift-iOS-SDK/BlueshiftEventAnalyticsHelper.m
@@ -29,6 +29,7 @@
         NSString *appName = [[BlueShiftAppData currentAppData] bundleIdentifier];
         NSString *pushDeepLinkURL = [self getValueBykey: pushDetailsDictionary andKey: kPushNotificationDeepLinkURLKey];
         NSString *timestamp = [self getCurrentUTCTimestamp];
+        NSString* notificationType = [pushDetailsDictionary objectForKey: kNotificationTypeIdentifierKey];
         if (bsft_user_uuid) {
             [pushTrackParametersMutableDictionary setObject:bsft_user_uuid forKey: kInAppNotificationModalUIDKey];
         }
@@ -50,7 +51,8 @@
         if ([self isNotNilAndNotEmpty:urlElement]) {
             [pushTrackParametersMutableDictionary setObject:urlElement forKey: kNotificationURLElementKey];
         }
-        if([[pushDetailsDictionary objectForKey: kNotificationTypeIdentifierKey] isEqualToString:kNotificationKey]) {
+        
+        if([notificationType isEqualToString:kNotificationKey] || [notificationType isEqualToString:kNotificationTypeActionable]) {
             // If pushDeepLinkURL is nil, then reassign url from pushDetailsDictionary
             if (![self isNotNilAndNotEmpty:pushDeepLinkURL]) {
                 pushDeepLinkURL = [self getValueBykey: pushDetailsDictionary andKey: kNotificationURLElementKey];

--- a/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationManager.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationManager.m
@@ -568,8 +568,8 @@
 
 - (void)createInAppNotification:(BlueShiftInAppNotification*)notification displayOnScreen:(NSString*)displayOnScreen {
     dispatch_async(dispatch_get_main_queue(), ^{
-        if (self.currentNotificationController != nil) {
-            [BlueshiftLog logInfo:@"Active In-app notification detected, skipped displaying current in-app." withDetails:nil methodName:nil];
+        if (self.currentNotificationController != nil || UIApplication.sharedApplication.applicationState != UIApplicationStateActive) {
+            [BlueshiftLog logInfo:@"Active In-app notification detected or app is not running in active state, skipped displaying current in-app." withDetails:nil methodName:nil];
             return;
         }
         


### PR DESCRIPTION
core SDK changes for custom actionable buttons
marked old category based deep linking APIs as deprecated
Added check for active state for in-app before displaying the in-app