### PR TITLE
Enhancements

### DIFF
--- a/BlueShift-iOS-SDK/BlueShift.h
+++ b/BlueShift-iOS-SDK/BlueShift.h
@@ -163,7 +163,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Calling this method will fetch in-app notifications manually from api and add them into the SDK database.
 /// @param success block to perform action when api call is successful
 /// @param failure block to perform action when api call is unsuccessful
-- (void)fetchInAppNotificationFromAPI:(void (^)(void))success failure:(void (^)(NSError*))failure;
+- (void)fetchInAppNotificationFromAPI:(void (^)(void))success failure:(void (^)(NSError* _Nullable))failure;
 
 /// Check if the url is from Blueshift
 /// @param url  url to check

--- a/BlueShift-iOS-SDK/BlueShift.m
+++ b/BlueShift-iOS-SDK/BlueShift.m
@@ -677,12 +677,13 @@ static const void *const kBlueshiftQueue = &kBlueshiftQueue;
 
 - (void)trackEventForEventName:(NSString *)eventName andParameters:(NSDictionary *)parameters canBatchThisEvent:(BOOL)isBatchEvent{
     NSMutableDictionary *parameterMutableDictionary = [NSMutableDictionary dictionary];
+    if (parameters) {
+        [parameterMutableDictionary addEntriesFromDictionary:parameters];
+    }
+    // Event name should not get overriden by the additional params
     if (eventName) {
         [parameterMutableDictionary setObject:eventName forKey:kEventGeneric];
     }
-    if (parameters) {
-        [parameterMutableDictionary addEntriesFromDictionary:parameters];
-    }    
     [self performRequestWithRequestParameters:[parameterMutableDictionary copy] canBatchThisEvent:isBatchEvent];
 }
 
@@ -749,6 +750,9 @@ static const void *const kBlueshiftQueue = &kBlueshiftQueue;
     return requestMutableParameters;
 }
 
+/// Add a tracking event to event processing queue. The track events could be delivered, open, click or dismiss.
+/// @param parameters tracking parameters
+/// @param isBatchEvent  BOOL to determine if the event needs to be batched or not.
 - (void)performRequestQueue:(NSMutableDictionary *)parameters canBatchThisEvent:(BOOL)isBatchEvent{
     @try {
         if([self validateSDKTrackingRequirements] == false) {

--- a/BlueShift-iOS-SDK/BlueShift.m
+++ b/BlueShift-iOS-SDK/BlueShift.m
@@ -895,7 +895,7 @@ static const void *const kBlueshiftQueue = &kBlueshiftQueue;
 }
 
 
-- (void)fetchInAppNotificationFromAPI:(void (^_Nonnull)(void))success failure:(void (^)(NSError*))failure {
+- (void)fetchInAppNotificationFromAPI:(void (^_Nonnull)(void))success failure:(void (^)( NSError* _Nullable ))failure {
     if ([[BlueShiftAppData currentAppData] getCurrentInAppNotificationStatus] == YES && _inAppNotificationMananger) {
         [BlueshiftInAppNotificationRequest fetchInAppNotificationWithSuccess:^(NSDictionary * apiResponse) {
             [self handleInAppMessageForAPIResponse:apiResponse withCompletionHandler:^(BOOL status) {

--- a/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
+++ b/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
@@ -455,7 +455,10 @@ static NSManagedObjectContext * _Nullable batchEventManagedObjectContext;
         
         lastProcessedPushNotificationUUID = [userInfo valueForKey:kInAppNotificationModalMessageUDIDKey];
         
-        [self trackAppOpenWithParameters:userInfo];
+        // fire app_open only for Blueshift push notifications
+        if ([BlueShift.sharedInstance isBlueshiftPushNotification:userInfo]) {
+            [self trackAppOpenWithParameters:userInfo];
+        }
         
         if (userInfo != nil && ([userInfo objectForKey: kPushNotificationDeepLinkURLKey] || [userInfo objectForKey: kNotificationURLElementKey])) {
             NSURL *deepLinkURL = [NSURL URLWithString: [userInfo objectForKey: kNotificationURLElementKey]];

--- a/BlueShift-iOS-SDK/BlueShiftDeviceData.h
+++ b/BlueShift-iOS-SDK/BlueShiftDeviceData.h
@@ -37,4 +37,9 @@
 - (NSDictionary *)toDictionary;
 - (void)saveDeviceDataForNotificationExtensionUse;
 
+/// This method will only work if the device id type is set as UUID. It will not work for device id types IDFV or IDFV:BundleId.
+/// Calling this method will reset the existing UUID device id and SDK will generate a new device id.
+/// This function will also fire an identify event to update the device to Blueshift.
+- (void)resetDeviceUUID;
+
 @end

--- a/BlueShift-iOS-SDK/BlueShiftDeviceData.m
+++ b/BlueShift-iOS-SDK/BlueShiftDeviceData.m
@@ -69,6 +69,11 @@ static BlueShiftDeviceData *_currentDeviceData = nil;
     return deviceUUID;
 }
 
+- (void)resetDeviceUUID {
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kBlueshiftDeviceIdSourceUUID];
+    [[BlueShift sharedInstance] identifyUserWithDetails:nil canBatchThisEvent:NO];
+}
+
 - (NSString *)deviceIDFV {
     NSString *idfvString = [[[UIDevice currentDevice] identifierForVendor] UUIDString];
     return idfvString;

--- a/BlueShift-iOS-SDK/BlueShiftRequestOperationManager.m
+++ b/BlueShift-iOS-SDK/BlueShiftRequestOperationManager.m
@@ -93,7 +93,7 @@ static BlueShiftRequestOperationManager *_sharedRequestOperationManager = nil;
                 handler(true, dictionary, error);
             } else {
                 [BlueshiftLog logAPICallInfo:[NSString stringWithFormat:@"GET - Fail %@",url] withDetails:nil statusCode:statusCode];
-                handler(false, nil, error);
+                handler(false, nil, [NSError errorWithDomain:@"Failed with error." code:statusCode userInfo:nil]);
             }
         } else {
             [BlueshiftLog logAPICallInfo:[NSString stringWithFormat:@"GET - Fail %@",url] withDetails:@{@"error":error} statusCode:statusCode];
@@ -129,7 +129,7 @@ static BlueShiftRequestOperationManager *_sharedRequestOperationManager = nil;
                 handler(true, dictionary, error);
             } else {
                 [BlueshiftLog logAPICallInfo:[NSString stringWithFormat:@"POST - Fail %@",url] withDetails:nil statusCode:statusCode];
-                handler(false, nil, error);
+                handler(false, nil, [NSError errorWithDomain:@"Failed with error." code:statusCode userInfo:nil]);
             }
         } else {
             [BlueshiftLog logAPICallInfo:[NSString stringWithFormat:@"POST - Fail %@",url] withDetails:@{@"error":error} statusCode:statusCode];

--- a/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotification.h
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotification.h
@@ -28,7 +28,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, readwrite, nullable) NSString *textColor;
 @property (nonatomic, copy, readwrite, nullable) NSString *backgroundColor;
 @property (nonatomic, copy, readwrite, nullable) NSString *iosLink;
-@property (nonatomic, copy, readwrite, nullable) NSString *shareableText;
 @property (nonatomic, copy, readwrite, nullable) NSString* buttonType;
 @property (nonatomic, assign, readwrite, nullable) NSNumber *backgroundRadius;
 @property (nonatomic, assign, readwrite, nullable) NSNumber *textSize;

--- a/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotification.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotification.m
@@ -36,10 +36,6 @@
                         [payloadDictionary objectForKey: kInAppNotificationModalPageKey] != [NSNull null]) {
                         self.iosLink = (NSString *)[payloadDictionary objectForKey: kInAppNotificationModalPageKey];
                     }
-                    if ([payloadDictionary objectForKey: kInAppNotificationModalSharableTextKey] &&
-                        [payloadDictionary objectForKey: kInAppNotificationModalSharableTextKey] != [NSNull null]) {
-                        self.shareableText = (NSString *)[payloadDictionary objectForKey: kInAppNotificationModalSharableTextKey];
-                    }
                     if ([payloadDictionary objectForKey: kInAppNotificationButtonTypeKey] &&
                         [payloadDictionary objectForKey: kInAppNotificationButtonTypeKey] != [NSNull null]) {
                         self.buttonType = (NSString *) [payloadDictionary objectForKey: kInAppNotificationButtonTypeKey];

--- a/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationConstant.h
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationConstant.h
@@ -63,7 +63,6 @@
 #define kInAppNotificationModalTextKey                          @"text"
 #define kInAppNotiificationModalTextColorKey                    @"text_color"
 #define kInAppNotificationModalPageKey                          @"ios_link"
-#define kInAppNotificationModalSharableTextKey                  @"shareable_text"
 #define kInAppNotificationModalBackgroundRadiusKey              @"background_radius"
 #define kInAppNotificationModalTextSizeKey                      @"text_size"
 #define kInAppNotificationButtonIndex                           @"btn_"

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationViewController.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationViewController.m
@@ -299,9 +299,11 @@
         } else if([BlueShift sharedInstance].appDelegate.mainAppDelegate && [[BlueShift sharedInstance].appDelegate.mainAppDelegate respondsToSelector:@selector(application:openURL:options:)] && [BlueshiftEventAnalyticsHelper isNotNilAndNotEmpty:buttonDetails.iosLink] && ![buttonDetails.iosLink isEqualToString:kInAppNotificationDismissDeepLinkURL]) {
             if (@available(iOS 9.0, *)) {
                 NSURL *deepLinkURL = [NSURL URLWithString: buttonDetails.iosLink];
-                NSDictionary *inAppOptions = [self getInAppOpenURLOptions:buttonDetails];
-                [[BlueShift sharedInstance].appDelegate.mainAppDelegate application:[UIApplication sharedApplication] openURL:deepLinkURL options:inAppOptions];
-                [BlueshiftLog logInfo:[NSString stringWithFormat:@"%@ %@",@"Delivered in-app notification deeplink to AppDelegate openURL method, Deep link - ", [deepLinkURL absoluteString]] withDetails:inAppOptions methodName:nil];
+                if (deepLinkURL) {
+                    NSDictionary *inAppOptions = [self getInAppOpenURLOptions:buttonDetails];
+                    [[BlueShift sharedInstance].appDelegate.mainAppDelegate application:[UIApplication sharedApplication] openURL:deepLinkURL options:inAppOptions];
+                    [BlueshiftLog logInfo:[NSString stringWithFormat:@"%@ %@",@"Delivered in-app notification deeplink to AppDelegate openURL method, Deep link - ", [deepLinkURL absoluteString]] withDetails:inAppOptions methodName:nil];
+                }
             }
         }
     } @catch (NSException *exception) {


### PR DESCRIPTION
removed the constants and vars for the shareableText
MOBL-1216 - Mark error object optional, returned error string instead of nil.
Added deepLinkURL null check
The event name should not get overridden by the additional param attributes
Added check to fire `app_open` only for Blueshift push notifications
Added method to reset the UUID type device id.