### PR TITLE
Deprecated is scene delegate configuration

### DIFF
--- a/BlueShift-iOS-SDK/BlueShift.m
+++ b/BlueShift-iOS-SDK/BlueShift.m
@@ -198,24 +198,35 @@ static const void *const kBlueshiftQueue = &kBlueshiftQueue;
 
 - (void)setupObservers {
     [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationWillEnterForegroundNotification object:nil queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification * _Nonnull note) {
-        [[BlueShift sharedInstance].appDelegate checkUNAuthorizationStatus];
-        [BlueShiftHttpRequestBatchUpload batchEventsUploadInBackground];
+        [self processWillEnterForground];
     }];
     
     [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidEnterBackgroundNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification * _Nonnull note) {
-        if([[UIDevice currentDevice] respondsToSelector:@selector(isMultitaskingSupported)]) {
-            // Initiate background single batch upload
-            @try {
-                __block UIBackgroundTaskIdentifier background_task;
-                background_task = [UIApplication.sharedApplication beginBackgroundTaskWithExpirationHandler:^ {
-                    [UIApplication.sharedApplication endBackgroundTask: background_task];
-                    background_task = UIBackgroundTaskInvalid;
-                }];
-                [BlueShiftHttpRequestBatchUpload batchEventsUploadInBackground];
-            } @catch (NSException *exception) {
-            }
-        }
+        [self processDidEnterBackground];
     }];
+}
+
+/// Check if the push permission status is changed when app enters foreground
+/// Also upload one batch of the batched events to Blueshift.
+- (void)processWillEnterForground {
+    [[BlueShift sharedInstance].appDelegate checkUNAuthorizationStatus];
+    [BlueShiftHttpRequestBatchUpload batchEventsUploadInBackground];
+}
+
+/// Upload one batch of the batched events to Blueshift when app enters background.
+- (void)processDidEnterBackground {
+    if([[UIDevice currentDevice] respondsToSelector:@selector(isMultitaskingSupported)]) {
+        // Initiate background single batch upload
+        @try {
+            __block UIBackgroundTaskIdentifier background_task;
+            background_task = [UIApplication.sharedApplication beginBackgroundTaskWithExpirationHandler:^ {
+                [UIApplication.sharedApplication endBackgroundTask: background_task];
+                background_task = UIBackgroundTaskInvalid;
+            }];
+            [BlueShiftHttpRequestBatchUpload batchEventsUploadInBackground];
+        } @catch (NSException *exception) {
+        }
+    }
 }
 
 - (void)initDeepLinks {

--- a/BlueShift-iOS-SDK/BlueShiftAppDelegate.h
+++ b/BlueShift-iOS-SDK/BlueShiftAppDelegate.h
@@ -62,8 +62,8 @@
 - (void)handleRemoteNotification:(NSDictionary *_Nonnull)userInfo;
 - (void)handleActionWithIdentifier: (NSString *_Nonnull)identifier forRemoteNotification:(NSDictionary *_Nonnull)notification completionHandler: (void (^_Nonnull)(void)) completionHandler;
 
-- (void)appDidEnterBackground:(UIApplication *_Nonnull)application;
-- (void)appDidBecomeActive:(UIApplication *_Nonnull)application;
+- (void)appDidEnterBackground:(UIApplication *_Nonnull)application DEPRECATED_MSG_ATTRIBUTE("SDK now automatically detects if app enters background, this method will be removed in upcoming releases.");
+- (void)appDidBecomeActive:(UIApplication *_Nonnull)application DEPRECATED_MSG_ATTRIBUTE("SDK now automatically detects if app enters foreground, this method will be removed in upcoming releases.");
 
 - (void)handleBlueshiftUniversalLinksForActivity:(NSUserActivity *_Nonnull)activity API_AVAILABLE(ios(8.0));
 - (void)handleBlueshiftUniversalLinksForURL:(NSURL *_Nonnull)url  API_AVAILABLE(ios(8.0));
@@ -76,8 +76,8 @@
 - (void)trackAppOpenOnAppLaunch:(NSDictionary *_Nullable)parameters;
 
 // SceneDelegate lifecycle methods
-- (void)sceneWillEnterForeground:(UIScene* _Nullable)scene API_AVAILABLE(ios(13.0));
-- (void)sceneDidEnterBackground:(UIScene* _Nullable)scene API_AVAILABLE(ios(13.0));
+- (void)sceneWillEnterForeground:(UIScene* _Nullable)scene API_AVAILABLE(ios(13.0)) DEPRECATED_MSG_ATTRIBUTE("SDK now automatically detects if app enters foreground, this method will be removed in upcoming releases.");
+- (void)sceneDidEnterBackground:(UIScene* _Nullable)scene API_AVAILABLE(ios(13.0)) DEPRECATED_MSG_ATTRIBUTE("SDK now automatically detects if app enters background, this method will be removed in upcoming releases.");
 
 /// Update current UNAuthorizationStatus in BlueshiftAppData on app launch and on app didBecomeActive
 - (void)checkUNAuthorizationStatus;

--- a/BlueShift-iOS-SDK/BlueShiftAppDelegate.h
+++ b/BlueShift-iOS-SDK/BlueShiftAppDelegate.h
@@ -63,7 +63,7 @@
 - (void)handleActionWithIdentifier: (NSString *_Nonnull)identifier forRemoteNotification:(NSDictionary *_Nonnull)notification completionHandler: (void (^_Nonnull)(void)) completionHandler;
 
 - (void)appDidEnterBackground:(UIApplication *_Nonnull)application DEPRECATED_MSG_ATTRIBUTE("SDK now automatically detects if app enters background, this method will be removed in upcoming releases.");
-- (void)appDidBecomeActive:(UIApplication *_Nonnull)application DEPRECATED_MSG_ATTRIBUTE("SDK now automatically detects if app enters foreground, this method will be removed in upcoming releases.");
+- (void)appDidBecomeActive:(UIApplication *_Nonnull)application DEPRECATED_MSG_ATTRIBUTE("SDK now automatically detects if app becomes active, this method will be removed in upcoming releases.");
 
 - (void)handleBlueshiftUniversalLinksForActivity:(NSUserActivity *_Nonnull)activity API_AVAILABLE(ios(8.0));
 - (void)handleBlueshiftUniversalLinksForURL:(NSURL *_Nonnull)url  API_AVAILABLE(ios(8.0));

--- a/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
+++ b/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
@@ -1008,30 +1008,17 @@ static NSManagedObjectContext * _Nullable batchEventManagedObjectContext;
 }
 
 - (void)appDidBecomeActive:(UIApplication *)application {
-    // Uploading previous Batch events if anything exists
-    //To make the code block asynchronous
-    [BlueShiftHttpRequestBatchUpload batchEventsUploadInBackground];
+    // Moved the code to the observer
 }
 
 - (void)applicationDidBecomeActive:(UIApplication *)application {
     if (self.mainAppDelegate && [self.mainAppDelegate respondsToSelector:@selector(applicationDidBecomeActive:)]) {
         [self.mainAppDelegate applicationDidBecomeActive:application];
     }
-    [self appDidBecomeActive:application];
 }
 
 - (void)appDidEnterBackground:(UIApplication *)application {
-    if([[UIDevice currentDevice] respondsToSelector:@selector(isMultitaskingSupported)])
-    {
-        __block UIBackgroundTaskIdentifier background_task;
-        background_task = [application beginBackgroundTaskWithExpirationHandler:^ {
-            
-            //Clean up code. Tell the system that we are done.
-            [application endBackgroundTask: background_task];
-            background_task = UIBackgroundTaskInvalid;
-        }];
-        [BlueShiftHttpRequestBatchUpload batchEventsUploadInBackground];
-    }
+    // Moved the code to the observer
 }
 
 
@@ -1039,7 +1026,6 @@ static NSManagedObjectContext * _Nullable batchEventManagedObjectContext;
     if (self.mainAppDelegate && [self.mainAppDelegate respondsToSelector:@selector(applicationDidEnterBackground:)]) {
         [self.mainAppDelegate applicationDidEnterBackground:application];
     }
-    [self appDidEnterBackground:application];
 }
 
 - (void) forwardInvocation:(NSInvocation *)anInvocation {
@@ -1237,36 +1223,11 @@ static NSManagedObjectContext * _Nullable batchEventManagedObjectContext;
 
 #pragma mark - Handle sceneDelegate lifecycle methods
 - (void)sceneWillEnterForeground:(UIScene* _Nullable)scene API_AVAILABLE(ios(13.0)) {
-    if (BlueShift.sharedInstance.config.isSceneDelegateConfiguration == YES) {
-        [self appDidBecomeActive:UIApplication.sharedApplication];
-    }
+    // Moved the code to the observer, 
 }
 
 - (void)sceneDidEnterBackground:(UIScene* _Nullable)scene API_AVAILABLE(ios(13.0)) {
-    if (BlueShift.sharedInstance.config.isSceneDelegateConfiguration == YES) {
-        if ([NSThread isMainThread] == YES) {
-            [self processSceneDidEnterBackground];
-        } else {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                [self processSceneDidEnterBackground];
-            });
-        }
-    }
-}
-
-/// Call appDidEnterBackground if all the scenes of the app are in background
-/// @warning - This function needs to be executed on the main thread
-- (void)processSceneDidEnterBackground API_AVAILABLE(ios(13.0)) {
-    BOOL areAllScenesInBackground = YES;
-    for (UIWindow* window in UIApplication.sharedApplication.windows) {
-        if (window.windowScene.activationState == UISceneActivationStateForegroundActive || window.windowScene.activationState == UISceneActivationStateForegroundInactive) {
-            areAllScenesInBackground = NO;
-            break;
-        }
-    }
-    if (areAllScenesInBackground == YES) {
-        [self appDidEnterBackground:UIApplication.sharedApplication];
-    }
+    // Moved the code to the observer
 }
 
 @end

--- a/BlueShift-iOS-SDK/BlueShiftConfig.h
+++ b/BlueShift-iOS-SDK/BlueShiftConfig.h
@@ -68,7 +68,7 @@ typedef NS_ENUM (NSUInteger,BlueshiftRegion) {
 
 /// Set this propery to true if the app has SceneDelegate configuration enabled.
 /// @note Default value is set to false.
-@property BOOL isSceneDelegateConfiguration API_AVAILABLE(ios(13.0));
+@property BOOL isSceneDelegateConfiguration API_AVAILABLE(ios(13.0)) DEPRECATED_MSG_ATTRIBUTE("From SDK v2.2.5, SDK will not use this property, instead it will check for scene delegate configuration dynamically if needed.");
 
 /// Set this property to false to stop the SDK from collectiong IDFA.
 /// @discussion With enableIDFACollection set as true, SDK will not ask user the device IDFA permission, but if the host app has asked for IDFA permission, and user has accepted it, then SDK collects it and sends to server.


### PR DESCRIPTION
- Deprecated the method calls for `appDidBecomeActive` and `appDidEnterBackground` to automate it using the observers. 
- Deprecated the methods `sceneWillEnterForeground` and `sceneDidEnterBackground` to automate it using the observers.
- Marked `isSceneDelegateConfiguration` flag as deprecated 