### PR TITLE
Feature/in app pn permission deeplink

### DIFF
--- a/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
+++ b/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
@@ -225,10 +225,19 @@ static NSManagedObjectContext * _Nullable batchEventManagedObjectContext;
 - (void)checkUNAuthorizationStatus {
     if (@available(iOS 10.0, *)) {
         [[UNUserNotificationCenter currentNotificationCenter] getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings * _Nonnull settings) {
-            if ([settings authorizationStatus] == UNAuthorizationStatusAuthorized) {
-                [[BlueShiftAppData currentAppData] setCurrentUNAuthorizationStatus:@YES];
+            if (@available(iOS 12.0, *)) {
+                // Set enable_push to true for provisional and athorized status
+                if ([settings authorizationStatus] == UNAuthorizationStatusAuthorized || [settings authorizationStatus] == UNAuthorizationStatusProvisional) {
+                    [[BlueShiftAppData currentAppData] setCurrentUNAuthorizationStatus:@YES];
+                } else {
+                    [[BlueShiftAppData currentAppData] setCurrentUNAuthorizationStatus:@NO];
+                }
             } else {
-                [[BlueShiftAppData currentAppData] setCurrentUNAuthorizationStatus:@NO];
+                if ([settings authorizationStatus] == UNAuthorizationStatusAuthorized) {
+                    [[BlueShiftAppData currentAppData] setCurrentUNAuthorizationStatus:@YES];
+                } else {
+                    [[BlueShiftAppData currentAppData] setCurrentUNAuthorizationStatus:@NO];
+                }
             }
             //Fire auto identify call in case any device attribute changes
             [self autoIdentifyCheck];

--- a/BlueShift-iOS-SDK/BlueShiftUserNotificationCenterDelegate.m
+++ b/BlueShift-iOS-SDK/BlueShiftUserNotificationCenterDelegate.m
@@ -19,7 +19,11 @@
 - (void)handleUserNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler API_AVAILABLE(ios(10.0)){
     NSDictionary *userInfo = notification.request.content.userInfo;
     [BlueshiftLog logInfo:@"Push Notification received" withDetails:userInfo methodName:nil];
-    completionHandler(UNAuthorizationOptionSound | UNAuthorizationOptionAlert | UNAuthorizationOptionBadge);
+    if (@available(iOS 14.0, *)) {
+        completionHandler(UNNotificationPresentationOptionBanner | UNNotificationPresentationOptionList | UNAuthorizationOptionSound | UNNotificationPresentationOptionBadge);
+    } else {
+        completionHandler(UNNotificationPresentationOptionAlert | UNNotificationPresentationOptionSound | UNNotificationPresentationOptionBadge);
+    }
 }
 
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler  API_AVAILABLE(ios(10.0)){

--- a/BlueShift-iOS-SDK/BlueShiftUserNotificationCenterDelegate.m
+++ b/BlueShift-iOS-SDK/BlueShiftUserNotificationCenterDelegate.m
@@ -20,7 +20,7 @@
     NSDictionary *userInfo = notification.request.content.userInfo;
     [BlueshiftLog logInfo:@"Push Notification received" withDetails:userInfo methodName:nil];
     if (@available(iOS 14.0, *)) {
-        completionHandler(UNNotificationPresentationOptionBanner | UNNotificationPresentationOptionList | UNAuthorizationOptionSound | UNNotificationPresentationOptionBadge);
+        completionHandler(UNNotificationPresentationOptionBanner | UNNotificationPresentationOptionList | UNNotificationPresentationOptionSound | UNNotificationPresentationOptionBadge);
     } else {
         completionHandler(UNNotificationPresentationOptionAlert | UNNotificationPresentationOptionSound | UNNotificationPresentationOptionBadge);
     }

--- a/BlueShift-iOS-SDK/BlueshiftConstants.h
+++ b/BlueShift-iOS-SDK/BlueshiftConstants.h
@@ -121,4 +121,16 @@
 #define kDefaultInAppTimeInterval               60
 #define kMinimumInAppTimeInterval               5
 
+// Push permission promt Localization keys
+#define kBSGoToSettingTitleLocalizedKey         @"BLUESHIFT_GOTOSETTING_ALERT_TITLE"
+#define kBSGoToSettingTextLocalizedKey          @"BLUESHIFT_GOTOSETTING_ALERT_TEXT"
+#define kBSGoToSettingOkayButtonLocalizedKey    @"BLUESHIFT_GOTOSETTING_ALERT_OKAY_BUTTON"
+#define kBSGoToSettingCancelButtonLocalizedKey  @"BLUESHIFT_GOTOSETTING_ALERT_CANCEL_BUTTON"
+
+// Push permission promt default text
+#define kBSGoToSettingDefaultTitle              @"Enable push notifications"
+#define kBSGoToSettingDefaultText               @"You have disabled Push notifications for your app, please go to settings to enable it."
+#define kBSGoToSettingDefaultOkayButton         @"Settings"
+#define kBSGoToSettingDefaultCancelButton       @"Not Now"
+
 #endif /* BlueshiftConstants_h */

--- a/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationConstant.h
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationConstant.h
@@ -138,5 +138,6 @@
 
 #define kInAppNotificationModalTimestampDateFormat              @"yyyy-MM-dd'T'HH:mm:ss.SSSZ"
 #define kInAppNotificationDismissDeepLinkURL                    @"blueshift://dismiss"
+#define kInAppNotificationReqPNPermissionDeepLinkURL            @"blueshift://req-push-permission"
 
 #endif /* BlueShiftInAppNotificationConstant_h */

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationViewController.h
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationViewController.h
@@ -13,7 +13,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef enum {
     BlueshiftInAppClickAction,
-    BlueshiftInAppDismissAction
+    BlueshiftInAppDismissAction,
+    BlueshiftAskPNPermission
 } BlueshiftInAppActions;
 
 @class BlueShiftNotificationViewController;
@@ -54,7 +55,7 @@ typedef enum {
 - (CGFloat)getLabelHeight:(UILabel*)label labelWidth:(CGFloat)width;
 - (UIView *)createNotificationWindow;
 - (void)sendActionEventAnalytics:(NSDictionary *)details forActionType:(BlueshiftInAppActions)action;
-- (void)processInAppActionForDeepLink:(NSString*)deepLink details:(NSDictionary*)details;
+- (void)processInAppActionForDeepLink:(NSString* _Nullable)deepLink details:(NSDictionary*)details;
 - (int)getTextAlignement:(NSString *)alignmentString;
 - (BOOL)isValidString:(NSString *)data;
 - (void)setBackgroundImageFromURL:(UIView *)notificationView;

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationViewController.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationViewController.m
@@ -296,6 +296,7 @@
             [self sendActionButtonTappedDelegate: buttonDetails];
         } else if([buttonDetails.iosLink isEqualToString:kInAppNotificationDismissDeepLinkURL] ||
                   [buttonDetails.iosLink isEqualToString:kInAppNotificationReqPNPermissionDeepLinkURL]) {
+            // Placeholder
             // Do not send the deep links with type dismiss or ask-pn-permission to openURL:options:
             // This case is already handled in the [self processInAppActionForDeepLink:]
         } else if([BlueShift sharedInstance].appDelegate.mainAppDelegate &&

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationWebViewController.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationWebViewController.m
@@ -285,6 +285,7 @@ API_AVAILABLE(ios(8.0))
             [[self inAppNotificationDelegate] actionButtonDidTapped: actionPayload];
         } else if([url.absoluteString isEqualToString:kInAppNotificationDismissDeepLinkURL] ||
                   [url.absoluteString isEqualToString:kInAppNotificationReqPNPermissionDeepLinkURL]) {
+            // Placeholder
             // Do not send the deep links with type dismiss or ask-pn-permission to openURL:options:
             // This case is already handled in the [self processInAppActionForDeepLink:]
         }


### PR DESCRIPTION
Added support for Provisional push permission, set enable_push = true if the Provisional status is granted. 
Added the `UNNotificationPresentationOptionBanner | UNNotificationPresentationOptionList` options for deprecated `alert` option
Added new deep link type for requesting push permission dialog
Added Localizable enabled prompt to go to setting