### PR TITLE
Development - Release 2.2.6

### DIFF
--- a/BlueShift-iOS-Extension-SDK.podspec
+++ b/BlueShift-iOS-Extension-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                  = "BlueShift-iOS-Extension-SDK"
-  s.version               = "2.2.5"
+  s.version               = "2.2.6"
   s.summary               = "iOS SDK for Push Notification Service Extension and Content Extension to support image and carousel image push notifications"
   s.homepage              = "https://github.com/blueshift-labs/Blueshift-iOS-SDK"
   s.license               = { :type => "MIT", :file => "LICENSE.md" }

--- a/BlueShift-iOS-SDK.podspec
+++ b/BlueShift-iOS-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                    = "BlueShift-iOS-SDK"
-  s.version                 = "2.2.5"
+  s.version                 = "2.2.6"
   s.summary                 = "iOS SDK for integrating Rich Push & In App Notifications, Universal Links and Analytics"
   s.homepage                = "https://github.com/blueshift-labs/Blueshift-iOS-SDK"
   s.license                 = { :type => "MIT", :file => "LICENSE.md" }

--- a/BlueShift-iOS-SDK.xcodeproj/project.pbxproj
+++ b/BlueShift-iOS-SDK.xcodeproj/project.pbxproj
@@ -728,7 +728,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -784,7 +784,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -813,7 +813,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.5;
+				MARKETING_VERSION = 2.2.6;
 				MODULEMAP_FILE = "BlueShift-iOS-SDK/ios.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Blueshift.BlueShift-iOS-SDK";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -843,7 +843,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.5;
+				MARKETING_VERSION = 2.2.6;
 				MODULEMAP_FILE = "BlueShift-iOS-SDK/ios.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Blueshift.BlueShift-iOS-SDK";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -874,7 +874,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.5;
+				MARKETING_VERSION = 2.2.6;
 				MODULEMAP_FILE = "BlueShift-iOS-Extension-SDK/ios.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Blueshift.BlueShift-iOS-Extension-SDK";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -905,7 +905,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.5;
+				MARKETING_VERSION = 2.2.6;
 				MODULEMAP_FILE = "BlueShift-iOS-Extension-SDK/ios.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Blueshift.BlueShift-iOS-Extension-SDK";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";

--- a/BlueShift-iOS-SDK/BlueShift.h
+++ b/BlueShift-iOS-SDK/BlueShift.h
@@ -56,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void) autoIntegration DEPRECATED_MSG_ATTRIBUTE("This method is deprecated, and will be replaced by the auto-integration using method swizzling. This method will be removed in a future SDK version.");
 
-- (void) setPushDelegate: (id) obj;
+- (void) setPushDelegate: (id) obj DEPRECATED_MSG_ATTRIBUTE("This method is deprecated, and will be removed in a future SDK version.");
 - (void) setPushParamDelegate: (id) obj DEPRECATED_MSG_ATTRIBUTE("This method is deprecated, and will be removed in a future SDK version.");
 - (NSString * _Nullable) getDeviceToken;
 - (void) setDeviceToken;

--- a/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
+++ b/BlueShift-iOS-SDK/BlueShiftAppDelegate.m
@@ -225,10 +225,19 @@ static NSManagedObjectContext * _Nullable batchEventManagedObjectContext;
 - (void)checkUNAuthorizationStatus {
     if (@available(iOS 10.0, *)) {
         [[UNUserNotificationCenter currentNotificationCenter] getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings * _Nonnull settings) {
-            if ([settings authorizationStatus] == UNAuthorizationStatusAuthorized) {
-                [[BlueShiftAppData currentAppData] setCurrentUNAuthorizationStatus:@YES];
+            if (@available(iOS 12.0, *)) {
+                // Set enable_push to true for provisional and athorized status
+                if ([settings authorizationStatus] == UNAuthorizationStatusAuthorized || [settings authorizationStatus] == UNAuthorizationStatusProvisional) {
+                    [[BlueShiftAppData currentAppData] setCurrentUNAuthorizationStatus:@YES];
+                } else {
+                    [[BlueShiftAppData currentAppData] setCurrentUNAuthorizationStatus:@NO];
+                }
             } else {
-                [[BlueShiftAppData currentAppData] setCurrentUNAuthorizationStatus:@NO];
+                if ([settings authorizationStatus] == UNAuthorizationStatusAuthorized) {
+                    [[BlueShiftAppData currentAppData] setCurrentUNAuthorizationStatus:@YES];
+                } else {
+                    [[BlueShiftAppData currentAppData] setCurrentUNAuthorizationStatus:@NO];
+                }
             }
             //Fire auto identify call in case any device attribute changes
             [self autoIdentifyCheck];

--- a/BlueShift-iOS-SDK/BlueShiftConfig.h
+++ b/BlueShift-iOS-SDK/BlueShiftConfig.h
@@ -17,7 +17,12 @@
 typedef NS_ENUM (NSUInteger,BlueshiftRegion) {
     BlueshiftRegionUS,
     BlueshiftRegionEU
-} ;
+};
+
+typedef NS_ENUM (NSUInteger,BlueshiftFilesLocation) {
+    BlueshiftFilesLocationDocumentDirectory,
+    BlueshiftFilesLocationLibraryDirectory
+};
 
 @class BlueShiftInAppNotificationDelegate;
 
@@ -130,6 +135,13 @@ typedef NS_ENUM (NSUInteger,BlueshiftRegion) {
 /// By default, the time-interval between two in-app messages (the interval when a message is dismissed and the next message appears while staying on same screen) is 60 seconds.
 /// Set this property in seconds to modify the time interval.
 @property(nonatomic) double BlueshiftInAppNotificationTimeInterval;
+
+/// SDK creates core data files by default in the app's Document directory. If your app supports sharing the Documents directory or Documents browser, then you can change this location to Library directory, so that the SDK files won't show up in the app's Document directory.
+/// Set this attribute to `.LibraryDirectory` if you dont want to use the Documents directory as SDK core data files location.
+/// @note If you want to stop using the Documents directory, SDK takes care of moving existing core data files(if present) from Documents directory to Library directory.
+/// @warning Shifting from Library directory to Document directory is not a recommended.
+/// If you want to stop using the Library directory and start using the Documents directory, SDK does not take care of moving the files from Library directory to Documents directory.
+@property BlueshiftFilesLocation sdkCoreDataFilesLocation;
 
 /// By default, SDK sets IDFV as the deviceIdSource.
 /// SDK provides IDFV, idfvBundleID, UUID and customDeviceId options as different device id sources.

--- a/BlueShift-iOS-SDK/BlueShiftConfig.m
+++ b/BlueShift-iOS-SDK/BlueShiftConfig.m
@@ -35,7 +35,9 @@
         self.blueshiftDeviceIdSource = BlueshiftDeviceIdSourceIDFV;
         
         // Default Region US
-        self.region = BlueshiftRegionUS;        
+        self.region = BlueshiftRegionUS;
+        
+        self.sdkCoreDataFilesLocation = BlueshiftFilesLocationDocumentDirectory;
     }
     return self;
 }

--- a/BlueShift-iOS-SDK/BlueShiftDeviceData.m
+++ b/BlueShift-iOS-SDK/BlueShiftDeviceData.m
@@ -84,7 +84,7 @@ static BlueShiftDeviceData *_currentDeviceData = nil;
     return [[UIDevice currentDevice] model];
 }
 
-- (NSString *)networkCarrierName {
+- (NSString *)getNetworkCarrierName {
     // Skip fetching network carrier for simulator
     #if TARGET_OS_SIMULATOR
         return nil;
@@ -128,9 +128,12 @@ static BlueShiftDeviceData *_currentDeviceData = nil;
         [deviceMutableDictionary setObject:self.operatingSystem forKey:kOSName];
     }
     
-    NSString *networkCarrier = self.networkCarrierName;
-    if (networkCarrier) {
-        [deviceMutableDictionary setObject: networkCarrier forKey:kNetworkCarrier];
+    if(!self.networkCarrierName) {
+        self.networkCarrierName = [self getNetworkCarrierName];
+    }
+    // Added check for simulator which returns nil value.
+    if (self.networkCarrierName) {
+        [deviceMutableDictionary setObject: self.networkCarrierName forKey:kNetworkCarrier];
     }
     
     if (self.currentLocation) {

--- a/BlueShift-iOS-SDK/BlueShiftUserNotificationCenterDelegate.m
+++ b/BlueShift-iOS-SDK/BlueShiftUserNotificationCenterDelegate.m
@@ -19,7 +19,11 @@
 - (void)handleUserNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler API_AVAILABLE(ios(10.0)){
     NSDictionary *userInfo = notification.request.content.userInfo;
     [BlueshiftLog logInfo:@"Push Notification received" withDetails:userInfo methodName:nil];
-    completionHandler(UNAuthorizationOptionSound | UNAuthorizationOptionAlert | UNAuthorizationOptionBadge);
+    if (@available(iOS 14.0, *)) {
+        completionHandler(UNNotificationPresentationOptionBanner | UNNotificationPresentationOptionList | UNNotificationPresentationOptionSound | UNNotificationPresentationOptionBadge);
+    } else {
+        completionHandler(UNNotificationPresentationOptionAlert | UNNotificationPresentationOptionSound | UNNotificationPresentationOptionBadge);
+    }
 }
 
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler  API_AVAILABLE(ios(10.0)){

--- a/BlueShift-iOS-SDK/BlueshiftConstants.h
+++ b/BlueShift-iOS-SDK/BlueshiftConstants.h
@@ -121,4 +121,16 @@
 #define kDefaultInAppTimeInterval               60
 #define kMinimumInAppTimeInterval               5
 
+// Push permission promt Localization keys
+#define kBSGoToSettingTitleLocalizedKey         @"BLUESHIFT_GOTOSETTING_ALERT_TITLE"
+#define kBSGoToSettingTextLocalizedKey          @"BLUESHIFT_GOTOSETTING_ALERT_TEXT"
+#define kBSGoToSettingOkayButtonLocalizedKey    @"BLUESHIFT_GOTOSETTING_ALERT_OKAY_BUTTON"
+#define kBSGoToSettingCancelButtonLocalizedKey  @"BLUESHIFT_GOTOSETTING_ALERT_CANCEL_BUTTON"
+
+// Push permission promt default text
+#define kBSGoToSettingDefaultTitle              @"Enable push notifications"
+#define kBSGoToSettingDefaultText               @"You have disabled Push notifications for your app, please go to settings to enable it."
+#define kBSGoToSettingDefaultOkayButton         @"Settings"
+#define kBSGoToSettingDefaultCancelButton       @"Not Now"
+
 #endif /* BlueshiftConstants_h */

--- a/BlueShift-iOS-SDK/BlueshiftConstants.h
+++ b/BlueShift-iOS-SDK/BlueshiftConstants.h
@@ -110,6 +110,7 @@
 #define kBSSPMResourceBundlePath                @"/BlueShift-iOS-SDK_BlueShift_iOS_SDK.bundle"
 #define kBSCoreDataMOMD                         @"momd"
 #define kBSCoreDataSQLiteFileName               @"BlueShift-iOS-SDK.sqlite"
+#define kBSCoreDataSQLiteLibraryPath            @"Application Support/Blueshift"
 #define kBSFrameWorkPath                        @"Frameworks/BlueShift_iOS_SDK.framework"
 #define kBSCreatedAt                            @"createdAt"
 

--- a/BlueShift-iOS-SDK/BlueshiftEventAnalyticsHelper.m
+++ b/BlueShift-iOS-SDK/BlueshiftEventAnalyticsHelper.m
@@ -194,7 +194,9 @@
 
 + (NSString *)getCurrentUTCTimestamp {
     NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    [dateFormatter setCalendar:[NSCalendar calendarWithIdentifier:NSCalendarIdentifierISO8601]];
     [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'"];
+    [dateFormatter setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US"]];
     [dateFormatter setTimeZone:[NSTimeZone timeZoneWithName:@"UTC"]];
     return [dateFormatter stringFromDate:[NSDate date]];
 }

--- a/BlueShift-iOS-SDK/BlueshiftVersion.h
+++ b/BlueShift-iOS-SDK/BlueshiftVersion.h
@@ -8,6 +8,6 @@
 #ifndef BlueShift_iOS_SDK_BlueshiftVersion_h
 #define BlueShift_iOS_SDK_BlueshiftVersion_h
 
-#define kBlueshiftSDKVersion             @"2.2.5"
+#define kBlueshiftSDKVersion             @"2.2.6"
 
 #endif

--- a/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationConstant.h
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationConstant.h
@@ -138,5 +138,6 @@
 
 #define kInAppNotificationModalTimestampDateFormat              @"yyyy-MM-dd'T'HH:mm:ss.SSSZ"
 #define kInAppNotificationDismissDeepLinkURL                    @"blueshift://dismiss"
+#define kInAppNotificationReqPNPermissionDeepLinkURL            @"blueshift://req-push-permission"
 
 #endif /* BlueShiftInAppNotificationConstant_h */

--- a/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationManager.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftInAppNotificationManager.m
@@ -61,7 +61,6 @@
     if ([[[BlueShift sharedInstance] config] inAppManualTriggerEnabled] == NO && [[BlueShiftAppData currentAppData] getCurrentInAppNotificationStatus] == YES) {
         [self fetchNowAndUpcomingInAppMessageFromDB];
         [self startInAppMessageFetchTimer];
-        [self deleteExpireInAppNotificationFromDataStore];
     }
 }
 
@@ -102,15 +101,25 @@
 
 #pragma mark - Insert, delete, update in-app notifications
 - (void)initializeInAppNotificationFromAPI:(NSMutableArray *)notificationArray handler:(void (^)(BOOL))handler {
-    if (notificationArray !=nil && notificationArray.count > 0) {
-        for (int i = 0; i < notificationArray.count ; i++) {
-            [self addInAppNotificationToDataStore: [notificationArray objectAtIndex: i]];
+    @try {
+        if (notificationArray !=nil && notificationArray.count > 0) {
+            for (int counter = 0; counter < notificationArray.count ; counter++) {
+                NSDictionary* inapp = [notificationArray objectAtIndex: counter];
+                double expiresAt = [inapp[kInAppNotificationDataKey][kInAppNotificationKey][kSilentNotificationTriggerEndTimeKey] doubleValue];
+                // Do not add expired in-app notifications to in-app DB.
+                if ([self checkInAppNotificationExpired:expiresAt] == NO) {
+                    [self addInAppNotificationToDataStore: inapp];
+                } else {
+                    [BlueshiftLog logInfo:@"Skipped adding expired in-app message to DB. MessageUUID -" withDetails:[inapp[kInAppNotificationDataKey] objectForKey: kInAppNotificationModalMessageUDIDKey] methodName:nil];
+                }
+            }
         }
+    } @catch (NSException *exception) {
     }
     handler(YES);
 }
 
-- (void) addInAppNotificationToDataStore: (NSDictionary *) payload {
+- (void)addInAppNotificationToDataStore: (NSDictionary *) payload {
     [self checkInAppNotificationExist: payload handler:^(BOOL status){
         if (status == NO) {
             if (nil == self.privateObjectContext) {
@@ -238,10 +247,9 @@
                 if (status && results != nil && [results count] > 0) {
                     for(int i = 0; i < results.count; i++) {
                         InAppNotificationEntity *notification = [results objectAtIndex:i];
-                        double timeDifferenceInDay = [self checkInAppNotificationExpired: [notification.createdAt doubleValue]];
-                        if (timeDifferenceInDay > 30 || count > 40) {
+                        if ([self getTimeDifference: notification.createdAt.doubleValue] > 30 || count > 40) {
                             [self deleteNotification: notification context: masterContext];
-                            [BlueshiftLog logInfo:@"Deleted Expired notification, messageId : " withDetails:notification.id methodName:nil];
+                            [BlueshiftLog logInfo:@"Deleted Displayed notification, messageId : " withDetails:notification.id methodName:nil];
                         }
                     }
                 }
@@ -286,17 +294,15 @@
     }
 }
 
-- (double)checkInAppNotificationExpired:(double)createdTime {
+- (BOOL)checkInAppNotificationExpired:(double)expiryTime {
     double currentTime =  [[NSDate date] timeIntervalSince1970];
-    NSDate *createdDate = [self convertMillisecondToDate: createdTime];
-    NSDate *currentDate = [self convertMillisecondToDate:currentTime];
-    
-    NSTimeInterval timeDifference = [currentDate timeIntervalSinceDate: createdDate];
-    return (timeDifference / (3600 * 24));
+    return currentTime > expiryTime;
 }
 
-- (NSDate *)convertMillisecondToDate:(double)seconds {
-    return [NSDate dateWithTimeIntervalSince1970:seconds];
+- (double)getTimeDifference:(double)createdTime {
+    double currentTime =  [[NSDate date] timeIntervalSince1970];
+    NSTimeInterval timeDifference = currentTime - createdTime;
+    return (timeDifference / (3600 * 24));
 }
 
 - (void)fetchLastInAppMessageIDFromDB:(void (^)(BOOL, NSString *, NSString *))handler {
@@ -534,7 +540,7 @@
             if (currentTime > endTime) {
                 /* discard notification if its expired. */
                 [self removeInAppNotificationFromDB: entity.objectID];
-                [BlueshiftLog logInfo:@"Deleted Expired notification, messageId : " withDetails:entity.id methodName:nil];
+                [BlueshiftLog logInfo:@"Deleted Expired pending notification, messageId : " withDetails:entity.id methodName:nil];
             } else {
                 /* For 'Now' category msg show it if time is not expired */
                 [nowFilteredResults addObject:entity];
@@ -546,7 +552,7 @@
             if (currentTime > endTime) {
                 /* discard notification if its expired. */
                 [self removeInAppNotificationFromDB: entity.objectID];
-                [BlueshiftLog logInfo:@"Deleted Expired notification, messageId : " withDetails:entity.id methodName:nil];
+                [BlueshiftLog logInfo:@"Deleted Expired pending notification, messageId : " withDetails:entity.id methodName:nil];
             } else if (startTime > currentTime) {
                 /* Wait for (startTime-currentTime) before IAM is shown */
                 continue;

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationViewController.h
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationViewController.h
@@ -13,7 +13,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef enum {
     BlueshiftInAppClickAction,
-    BlueshiftInAppDismissAction
+    BlueshiftInAppDismissAction,
+    BlueshiftAskPNPermission
 } BlueshiftInAppActions;
 
 @class BlueShiftNotificationViewController;
@@ -54,7 +55,7 @@ typedef enum {
 - (CGFloat)getLabelHeight:(UILabel*)label labelWidth:(CGFloat)width;
 - (UIView *)createNotificationWindow;
 - (void)sendActionEventAnalytics:(NSDictionary *)details forActionType:(BlueshiftInAppActions)action;
-- (void)processInAppActionForDeepLink:(NSString*)deepLink details:(NSDictionary*)details;
+- (void)processInAppActionForDeepLink:(NSString* _Nullable)deepLink details:(NSDictionary*)details;
 - (int)getTextAlignement:(NSString *)alignmentString;
 - (BOOL)isValidString:(NSString *)data;
 - (void)setBackgroundImageFromURL:(UIView *)notificationView;

--- a/BlueShift-iOS-SDK/InApps/BlueShiftNotificationWebViewController.m
+++ b/BlueShift-iOS-SDK/InApps/BlueShiftNotificationWebViewController.m
@@ -272,16 +272,26 @@ API_AVAILABLE(ios(8.0))
         if (url) {
             NSString *encodedURLString = [BlueShiftInAppNotificationHelper getEncodedURLString:url.absoluteString];
             details = @{kNotificationURLElementKey:encodedURLString};
+            [self processInAppActionForDeepLink:url.absoluteString details:details];
+        } else {
+            [self processInAppActionForDeepLink:nil details:details];
         }
-        [self processInAppActionForDeepLink:url.absoluteString details:details];
         NSDictionary *inAppOptions = [self getInAppOpenURLOptions:nil];
         if (self.inAppNotificationDelegate && [self.inAppNotificationDelegate respondsToSelector:@selector(actionButtonDidTapped:)]) {
-            NSString *deepLink = url.absoluteString ? url.absoluteString : @"";
+            NSString *deepLink = (url && url.absoluteString) ? url.absoluteString : @"";
             NSMutableDictionary *actionPayload = [[NSMutableDictionary alloc] initWithDictionary:inAppOptions];
             [actionPayload setObject: deepLink forKey: kInAppNotificationModalPageKey];
             [actionPayload setObject:kInAppNotificationButtonTypeOpenKey forKey: kInAppNotificationButtonTypeKey];
             [[self inAppNotificationDelegate] actionButtonDidTapped: actionPayload];
-        } else if([BlueShift sharedInstance].appDelegate.mainAppDelegate && [[BlueShift sharedInstance].appDelegate.mainAppDelegate respondsToSelector:@selector(application:openURL:options:)] && [BlueshiftEventAnalyticsHelper isNotNilAndNotEmpty:url.absoluteString] && ![url.absoluteString isEqualToString:kInAppNotificationDismissDeepLinkURL]) {
+        } else if([url.absoluteString isEqualToString:kInAppNotificationDismissDeepLinkURL] ||
+                  [url.absoluteString isEqualToString:kInAppNotificationReqPNPermissionDeepLinkURL]) {
+            // Placeholder
+            // Do not send the deep links with type dismiss or ask-pn-permission to openURL:options:
+            // This case is already handled in the [self processInAppActionForDeepLink:]
+        }
+        else if(url && [BlueShift sharedInstance].appDelegate.mainAppDelegate &&
+                  [[BlueShift sharedInstance].appDelegate.mainAppDelegate respondsToSelector:@selector(application:openURL:options:)] &&
+                  [BlueshiftEventAnalyticsHelper isNotNilAndNotEmpty:url.absoluteString]) {
             if (@available(iOS 9.0, *)) {
                 [[BlueShift sharedInstance].appDelegate.mainAppDelegate application:[UIApplication sharedApplication] openURL: url options:inAppOptions];
                 [BlueshiftLog logInfo:[NSString stringWithFormat:@"%@ %@",@"Delivered in-app notification deeplink to AppDelegate openURL method, Deep link - ", [url absoluteString]] withDetails:inAppOptions methodName:nil];


### PR DESCRIPTION
- Added `blueshift://req-push-permission` deep link support for in-app notifications to display push permission dialog. Added localization support to change the dialog text based on app language.
- Provision to change the core data files location using `config.sdkCoreDataFilesLocation` flag.
- Added fix to not fire `delivered` event for expired in-app notifications if received any via in-app API.
- Added support for the Provisional Push notification authorization.
- Added provision to cache the carrier name to avoid fetching it every time.
- Added default calendar and locale setting to create the timestamp.
- Added notification presentation options based on the iOS versions.
- Improved logging.